### PR TITLE
Rename categories, add NSW/PC-only natives

### DIFF
--- a/natives.json
+++ b/natives.json
@@ -1469,7 +1469,7 @@
       "return_type": "int"
     },
     "0x437588E6": {
-      "name": "_REPAIR_INCAPACITATION",
+      "name": "ACTOR_REPAIR_INCAPACITATION",
       "comment": "",
       "params": [
         {
@@ -3093,7 +3093,7 @@
       "return_type": "void"
     },
     "0x5FEA3E61": {
-      "name": "_SET_CUSTOM_ANIM_SPEED_SCALE",
+      "name": "SET_CUSTOM_ANIM_SPEED",
       "comment": "",
       "params": [
         {
@@ -3795,7 +3795,7 @@
       "return_type": "void"
     },
     "0x9028B082": {
-      "name": "_0x9028B082",
+      "name": "CLEAR_ALL_CORPSES",
       "comment": "",
       "params": [],
       "return_type": "int"
@@ -11441,7 +11441,7 @@
       "return_type": "int"
     },
     "0xDD0320CB": {
-      "name": "_0xDD0320CB",
+      "name": "AUDIO_CLEAR_CONVERSATION_HISTORY",
       "comment": "",
       "params": [],
       "return_type": "void"
@@ -11579,7 +11579,7 @@
       "return_type": "int"
     },
     "0x12D077CA": {
-      "name": "_0x12D077CA",
+      "name": "SAY_SINGLE_LINE_STRING_OVER_PAIN",
       "comment": "",
       "params": [
         {
@@ -11745,7 +11745,7 @@
       "return_type": "int"
     },
     "0x3F226995": {
-      "name": "_0x3F226995",
+      "name": "SAY_SINGLE_LINE_STRING_SCRIPTED_INTERRUPT",
       "comment": "",
       "params": [
         {
@@ -12108,7 +12108,7 @@
       "return_type": "int"
     },
     "0x2B1B76E8": {
-      "name": "GRINGO_SET_MONEY_PRESENCE",
+      "name": "_0x2B1B76E8",
       "comment": "",
       "params": [
         {
@@ -13174,13 +13174,13 @@
       "return_type": "int"
     },
     "0x9B083FD2": {
-      "name": "_0x9B083FD2",
+      "name": "GET_LOOKSTICK_INVERT_Y",
       "comment": "",
       "params": [],
       "return_type": "int"
     },
     "0x063F900A": {
-      "name": "_0x063F900A",
+      "name": "SET_LOOKSTICK_INVERT_Y",
       "comment": "",
       "params": [
         {
@@ -13229,7 +13229,7 @@
       "return_type": "int"
     },
     "0x382C47C5": {
-      "name": "_0x382C47C5",
+      "name": "SET_GAME_CAMERA_VEHICLE_MODE",
       "comment": "",
       "params": [
         {
@@ -15776,7 +15776,7 @@
       "return_type": "void"
     },
     "0x93050734": {
-      "name": "_0x93050734",
+      "name": "GET_CUTSCENE_TUNER_CUTSCENEOBJECT",
       "comment": "",
       "params": [],
       "return_type": "int"
@@ -17118,7 +17118,7 @@
       "return_type": "Any"
     },
     "0xC1F9AC6B": {
-      "name": "_0xC1F9AC6B",
+      "name": "GET_ANALOGUE_ACTION",
       "comment": "PC only",
       "params": [
         {
@@ -17597,7 +17597,7 @@
       "return_type": "void"
     },
     "0xE1124E00": {
-      "name": "_0xE1124E00",
+      "name": "RESET_STORED_DATA",
       "comment": "",
       "params": [],
       "return_type": "void"
@@ -19102,7 +19102,7 @@
       "return_type": "int"
     },
     "0xEA8E6112": {
-      "name": "_0xEA8E6112",
+      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_ACTORENUM",
       "comment": "",
       "params": [
         {
@@ -20281,7 +20281,7 @@
       "return_type": "int"
     },
     "0xBC58F1EA": {
-      "name": "_GET_ITERATION_SET",
+      "name": "GET_OBJECTSET_FOR_EVENT_TYPE",
       "comment": "",
       "params": [
         {
@@ -22979,7 +22979,7 @@
       "return_type": "int"
     },
     "0x80317230": {
-      "name": "_GET_USE_COMPONENT_2",
+      "name": "GRINGO_SET_USABLE_BY_PLAYER",
       "comment": "",
       "params": [
         {
@@ -23585,7 +23585,7 @@
       "return_type": "int"
     },
     "0x8C2914C4": {
-      "name": "_0x8C2914C4",
+      "name": "GRINGO_SET_REUSE_DELAY",
       "comment": "",
       "params": [
         {
@@ -28385,7 +28385,7 @@
       "return_type": "Any"
     },
     "0x0E0EFB13": {
-      "name": "_GET_AN_EQUIP_SLOT",
+      "name": "GET_ITEM_EQUIPSLOT",
       "comment": "",
       "params": [
         {
@@ -28547,7 +28547,7 @@
       "return_type": "Any"
     },
     "0xA8040D70": {
-      "name": "_0xA8040D70",
+      "name": "ACTOR_GET_CURRENT_EQUIP_SLOT",
       "comment": "",
       "params": [],
       "return_type": "Any"
@@ -30731,7 +30731,7 @@
       "return_type": "int"
     },
     "0xC1265E7F": {
-      "name": "_0xC1265E7F",
+      "name": "LEASH_SET_LOCATOR_POSITION_VISUAL",
       "comment": "",
       "params": [
         {
@@ -30960,7 +30960,7 @@
       "return_type": "int"
     },
     "0x2DC768BB": {
-      "name": "_0x2DC768BB",
+      "name": "SET_MINIGAME_SCRIPT_OVERRIDE",
       "comment": "",
       "params": [
         {
@@ -30971,7 +30971,7 @@
       "return_type": "int"
     },
     "0x8275FDD4": {
-      "name": "_0x8275FDD4",
+      "name": "SET_MINIGAME_WIN_STATE",
       "comment": "",
       "params": [
         {
@@ -32003,7 +32003,7 @@
       "return_type": "int"
     },
     "0x1C147E14": {
-      "name": "_0x1C147E14",
+      "name": "NET_OBJECT_SET_SCRIPT_INT",
       "comment": "",
       "params": [
         {
@@ -32018,7 +32018,7 @@
       "return_type": "int"
     },
     "0xCA6231C1": {
-      "name": "_0xCA6231C1",
+      "name": "NET_OBJECT_GET_SCRIPT_INT",
       "comment": "",
       "params": [
         {
@@ -32155,7 +32155,7 @@
       "return_type": "int"
     },
     "0x106CE441": {
-      "name": "_0x106CE441",
+      "name": "NET_POSSE_IS_INVITE_PRESENT",
       "comment": "",
       "params": [
         {
@@ -32166,7 +32166,7 @@
       "return_type": "int"
     },
     "0x6A7B9FAD": {
-      "name": "_0x6A7B9FAD",
+      "name": "NET_POSSE_IS_REQUEST_PRESENT",
       "comment": "",
       "params": [
         {
@@ -32461,7 +32461,7 @@
       "return_type": "void"
     },
     "0xE5645CB3": {
-      "name": "_0xE5645CB3",
+      "name": "NET_GET_KILL_EFFECT_ON",
       "comment": "",
       "params": [],
       "return_type": "int"
@@ -32868,7 +32868,7 @@
       "return_type": "int"
     },
     "0x85049505": {
-      "name": "_0x85049505",
+      "name": "GAME_INSTANCE_SET_REGION",
       "comment": "",
       "params": [
         {
@@ -33040,7 +33040,7 @@
       "return_type": "int"
     },
     "0x4F652A00": {
-      "name": "_0x4F652A00",
+      "name": "NET_GET_LOCAL_GAMER_RANK",
       "comment": "",
       "params": [],
       "return_type": "int"
@@ -33160,8 +33160,8 @@
       "return_type": "int"
     },
     "0x293C3288": {
-      "name": "_0x293C3288",
-      "comment": "",
+      "name": "GET_RELATION_ONLY",
+      "comment": "Name might be false positive",
       "params": [],
       "return_type": "int"
     },
@@ -33301,7 +33301,7 @@
       "return_type": "int"
     },
     "0x9BC05C90": {
-      "name": "_0x9BC05C90",
+      "name": "NET_GET_GAMER_HEX_COLOR",
       "comment": "",
       "params": [
         {
@@ -33557,7 +33557,7 @@
       "return_type": "int"
     },
     "0xD4C7E0D5": {
-      "name": "_0xD4C7E0D5",
+      "name": "NET_PLAYER_LIST_TIMER_ENABLE_FLASHING",
       "comment": "",
       "params": [
         {
@@ -34650,7 +34650,7 @@
       "return_type": "int"
     },
     "0x177A3843": {
-      "name": "_0x177A3843",
+      "name": "CREATE_VOLUME_SET_IN_LAYOUT",
       "comment": "",
       "params": [
         {
@@ -36149,7 +36149,7 @@
       "return_type": "void"
     },
     "0xB104FF3E": {
-      "name": "_0xB104FF3E",
+      "name": "ADD_TO_VOLUME_SET",
       "comment": "",
       "params": [
         {
@@ -36880,7 +36880,7 @@
       "return_type": "int"
     },
     "0x1A4C98C1": {
-      "name": "_0x1A4C98C1",
+      "name": "SET_RMPTFX_SCALE",
       "comment": "",
       "params": [
         {
@@ -40844,7 +40844,7 @@
       "return_type": "int"
     },
     "0x4A05AA7D": {
-      "name": "_0x4A05AA7D",
+      "name": "ATTACH_PHYSINST_TO_WORLD2_HIGH_QUALITY",
       "comment": "",
       "params": [
         {
@@ -41104,7 +41104,7 @@
       "return_type": "int"
     },
     "0x34960D06": {
-      "name": "_0x34960D06",
+      "name": "NET_GAMER_ICON_FORCE_HIDDEN",
       "comment": "",
       "params": [
         {
@@ -41234,7 +41234,7 @@
       "return_type": "void"
     },
     "0x08D84437": {
-      "name": "_0x08D84437",
+      "name": "NET_GAMER_BLIPS_FORCE_VISIBLE",
       "comment": "",
       "params": [
         {
@@ -41256,7 +41256,7 @@
       "return_type": "Any"
     },
     "0x3DD6E36A": {
-      "name": "_0x3DD6E36A",
+      "name": "NET_GAMER_SET_BLIP_FORCE_HIDDEN",
       "comment": "",
       "params": [
         {
@@ -41282,7 +41282,7 @@
       "return_type": "int"
     },
     "0x25F8C46A": {
-      "name": "_0x25F8C46A",
+      "name": "NET_GAMER_IS_BLIP_VISIBLE",
       "comment": "",
       "params": [
         {
@@ -41505,7 +41505,7 @@
       "return_type": "int"
     },
     "0x0C1B8DEA": {
-      "name": "_LINK_ACTOR_ENUM_TO_POPULATION",
+      "name": "LINK_ACTORENUM_TO_POPULATION",
       "comment": "",
       "params": [
         {
@@ -41544,7 +41544,7 @@
       "return_type": "int"
     },
     "0x93B6135B": {
-      "name": "_LINK_ACTOR_ENUM_TO_POPULATION_TIMED",
+      "name": "LINK_ACTORENUM_TO_POPULATION_TIMED",
       "comment": "",
       "params": [
         {
@@ -41567,7 +41567,7 @@
       "return_type": "int"
     },
     "0x84F75008": {
-      "name": "_UNLINK_ACTOR_ENUM_FROM_POPULATION",
+      "name": "UNLINK_ACTORENUM_FROM_POPULATION",
       "comment": "",
       "params": [
         {
@@ -42704,7 +42704,7 @@
       "return_type": "void"
     },
     "0x09D4CDEF": {
-      "name": "_SET_MAXIMUM_SHADOW_SPOTLIGHT_CASCADE_COUNT",
+      "name": "SET_MAXIMUM_SPOTLIGHT_CASCADE_COUNT",
       "comment": "PS4/Switch/PC only",
       "params": [
         {
@@ -47274,7 +47274,7 @@
       "return_type": "int"
     },
     "0xF4429710": {
-      "name": "_0xF4429710",
+      "name": "SET_ACTOR_CAN_BE_HARDLOCKED",
       "comment": "",
       "params": [
         {
@@ -51579,7 +51579,7 @@
       "return_type": "void"
     },
     "0xA7A672FA": {
-      "name": "_TRAIN_ADD_NEW_TRAIN_CAR_FROM_ENUM",
+      "name": "TRAIN_ADD_TRAIN_CAR_FROM_ENUM",
       "comment": "",
       "params": [
         {
@@ -51796,7 +51796,7 @@
       "return_type": "Any"
     },
     "0xADE865AE": {
-      "name": "_TRAIN_SET_AUTO_PILOT_ENABLED",
+      "name": "TRAIN_SET_AUTOPILOT_ENABLE",
       "comment": "",
       "params": [
         {
@@ -51815,7 +51815,7 @@
       "return_type": "Any"
     },
     "0x6A9C8E5B": {
-      "name": "_TRAIN_SET_AUDIO_ENABLED",
+      "name": "TRAIN_SET_AUDIO_ENABLE",
       "comment": "",
       "params": [
         {
@@ -52608,7 +52608,7 @@
       "return_type": "int"
     },
     "0xCCB57C38": {
-      "name": "_0xCCB57C38",
+      "name": "GET_AMMO_ENUM_STRING_FROM_ENUM",
       "comment": "",
       "params": [
         {

--- a/natives.json
+++ b/natives.json
@@ -10210,7 +10210,7 @@
       "return_type": "int"
     },
     "0x900C489A": {
-      "name": "_0x900C489A",
+      "name": "AUDIO_CLEAR_ALL_ALTERNATE_CONTEXTS",
       "comment": "",
       "params": [],
       "return_type": "int"
@@ -10313,7 +10313,7 @@
           "type": "Any",
           "name": "p0"
         }
-	  ],
+      ],
       "return_type": "void"
     },
     "0x5E07BF3F": {
@@ -16060,7 +16060,7 @@
       "return_type": "int"
     },
     "0xF4D0807E": {
-      "name": "_DLC_CLIST",
+      "name": "DLC_INIT_STRINGTABLE_STREAMABLES",
       "comment": "",
       "params": [
         {
@@ -16086,7 +16086,7 @@
       "return_type": "BOOL"
     },
     "0x2F78AEFA": {
-      "name": "_0x2F78AEFA",
+      "name": "DLC_UNMOUNT_PACK",
       "comment": "PS4/Switch/PC only",
       "params": [
         {
@@ -17322,49 +17322,49 @@
       "return_type": "void"
     },
     "0x28246500": {
-      "name": "_0x28246500",
+      "name": "_SET_IS_ZOMBIE_DLC_ACTIVE",
       "comment": "PS4/Switch/PC only",
       "params": [],
       "return_type": "void"
     },
     "0x8CF15FCB": {
-      "name": "_0x8CF15FCB",
+      "name": "_IS_ZOMBIE_DLC_ACTIVE",
       "comment": "",
       "params": [],
       "return_type": "int"
     },
     "0x4A8066FB": {
-      "name": "_0x4A8066FB",
+      "name": "_LOAD_ZOMBIE_DLC_ASSETS",
       "comment": "",
       "params": [],
       "return_type": "int"
     },
     "0x1DDB57A6": {
-      "name": "_0x1DDB57A6",
+      "name": "_LOAD_ZOMBIE_DLC_ASSETS_MP",
       "comment": "",
       "params": [],
       "return_type": "int"
     },
     "0x88863344": {
-      "name": "_0x88863344",
+      "name": "_UNLOAD_ZOMBIE_DLC_ASSETS",
       "comment": "",
       "params": [],
       "return_type": "int"
     },
     "0xE7371670": {
-      "name": "_0xE7371670",
+      "name": "_IS_ZOMBIE_DLC_LOAD_COMPLETE",
       "comment": "",
       "params": [],
       "return_type": "int"
     },
     "0x03E2B631": {
-      "name": "_0x03E2B631",
+      "name": "_IS_ZOMBIE_DLC_UNLOAD_COMPLETE",
       "comment": "",
       "params": [],
       "return_type": "int"
     },
     "0xCA840DBB": {
-      "name": "_0xCA840DBB",
+      "name": "_SET_ZOMBIE_DLC_PHOSPHORUS_AMMO_ACTIVE",
       "comment": "",
       "params": [
         {
@@ -17375,7 +17375,7 @@
       "return_type": "Any"
     },
     "0x4F3F3CA5": {
-      "name": "_0x4F3F3CA5",
+      "name": "_IS_ZOMBIE_DLC_PHOSPHORUS_AMMO_ACTIVE",
       "comment": "",
       "params": [],
       "return_type": "int"
@@ -17598,7 +17598,7 @@
       "return_type": "int"
     },
     "0xE437932A": {
-      "name": "_0xE437932A",
+      "name": "SET_USE_ACTOR_STAGGER",
       "comment": "PS4/Switch/PC only",
       "params": [],
       "return_type": "int"
@@ -17974,6 +17974,28 @@
     }
   },
   "CORE": {
+    "0x14993D3B": {
+      "name": "_0x14993D3B",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xE8AB1D5B": {
+      "name": "_0xE8AB1D5B",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
     "0x505A8057": {
       "name": "SET_DEBUG_DRAW",
       "comment": "",
@@ -18987,6 +19009,72 @@
       ],
       "return_type": "float"
     },
+    "0x062C5047": {
+      "name": "_0x062C5047",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xDA674AE0": {
+      "name": "_0xDA674AE0",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x973F30EE": {
+      "name": "_0x973F30EE",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xC1F9AC6B": {
+      "name": "_0xC1F9AC6B",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x4586516D": {
+      "name": "_0x4586516D",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x7E452200": {
+      "name": "_0x7E452200",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
     "0x9AAF7E28": {
       "name": "GET_STICK_X",
       "comment": "",
@@ -19068,6 +19156,116 @@
         }
       ],
       "return_type": "int"
+    },
+    "0x5598C970": {
+      "name": "_0x5598C970",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xDC4B85A8": {
+      "name": "_0xDC4B85A8",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xB59B352A": {
+      "name": "_0xB59B352A",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x5AC5CE22": {
+      "name": "_0x5AC5CE22",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x07D4535A1": {
+      "name": "_0x07D4535A1",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x55ADBA8B": {
+      "name": "GET_MOUSE_AXIS_X",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x455A19E4": {
+      "name": "GET_MOUSE_AXIS_Y",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x88F07597": {
+      "name": "_0x88F07597",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x3A62D87D": {
+      "name": "_0x3A62D87D",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x5FE80264": {
+      "name": "_0x5FE80264",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
     },
     "0xF7974EBA": {
       "name": "DEBUG_DRAW_VECTOR",
@@ -19568,6 +19766,17 @@
       "params": [],
       "return_type": "int"
     },
+    "0x580D21D9": {
+      "name": "_0x580D21D9",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
     "0xAABE1330": {
       "name": "DOES_FILE_EXIST",
       "comment": "",
@@ -19597,17 +19806,39 @@
       "params": [],
       "return_type": "BOOL"
     },
-	"0x99989FCD": {
+    "0x99989FCD": {
       "name": "IS_PS4",
       "comment": "PS4/Switch/PC only",
       "params": [],
       "return_type": "BOOL"
     },
-	"0x92E03425": {
+    "0x92E03425": {
       "name": "IS_SWITCH",
       "comment": "PS4/Switch/PC only",
       "params": [],
       "return_type": "BOOL"
+    },
+    "0xFC7766A0": {
+      "name": "_0xFC7766A0",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x16C54BC5": {
+      "name": "IS_PC",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
     },
     "0xB427CB25": {
       "name": "_0xB427CB25",
@@ -19620,6 +19851,28 @@
       "comment": "",
       "params": [],
       "return_type": "int"
+    },
+    "0xFB46B5D6": {
+      "name": "_0xFB46B5D6",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xFDDB1BFA": {
+      "name": "_0xFDDB1BFA",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
     },
     "0xC3C0F1F2": {
       "name": "IS_PLAYER_SIGNED_IN",
@@ -19721,7 +19974,7 @@
       "return_type": "int"
     },
     "0x81A7CDB6": {
-      "name": "_0x81A7CDB6",
+      "name": "SET_TREE_COST_MODIFIER",
       "comment": "PS4/Switch/PC only",
       "params": [
         {
@@ -19732,7 +19985,7 @@
       "return_type": "Any"
     },
     "0x2A04518E": {
-      "name": "_0x2A04518E",
+      "name": "SET_USES_QUAD_IK_FIX",
       "comment": "PS4/Switch/PC only",
       "params": [
         {
@@ -19743,7 +19996,7 @@
       "return_type": "Any"
     },
     "0x4FC61E5F": {
-      "name": "_0x4FC61E5F",
+      "name": "SET_VISIBILITY_FOV_CLAMP",
       "comment": "PS4/Switch/PC only",
       "params": [
         {
@@ -23372,6 +23625,17 @@
       ],
       "return_type": "void"
     },
+    "0x247348C5": {
+      "name": "_0x247348C5",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
     "0x545EC471": {
       "name": "UI_HIDE_PROMPT",
       "comment": "",
@@ -25153,6 +25417,17 @@
         }
       ],
       "return_type": "void"
+    },
+    "0x8A8BDCF9": {
+      "name": "_0x8A8BDCF9",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
     },
     "0x4486E8C7": {
       "name": "CLEAR_NEWSPAPER",
@@ -34319,7 +34594,7 @@
       ],
       "return_type": "int"
     },
-	"0x7614AEBA": {
+    "0x7614AEBA": {
       "name": "_0x7614AEBA",
       "comment": "PS4/Switch/PC only",
       "params": [],
@@ -35917,7 +36192,7 @@
       "return_type": "int*"
     },
     "0x489A2B93": {
-      "name": "_0x489A2B93",
+      "name": "NET_SET_UNLOCK",
       "comment": "PS4/Switch/PC only",
       "params": [],
       "return_type": "int*"
@@ -40175,6 +40450,17 @@
       ],
       "return_type": "void"
     },
+    "0x968F0317": {
+      "name": "_0x968F0317",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
     "0x0911BA31": {
       "name": "SET_ACTOR_STREAMING_HIGH_PRIORITY",
       "comment": "",
@@ -41303,7 +41589,7 @@
       "return_type": "void"
     },
     "0x09D4CDEF": {
-      "name": "_0x09D4CDEF",
+      "name": "_SET_MAXIMUM_SHADOW_SPOTLIGHT_CASCADE_COUNT",
       "comment": "PS4/Switch/PC only",
       "params": [
         {
@@ -45446,6 +45732,28 @@
       ],
       "return_type": "int"
     },
+    "0x5B4999C2": {
+      "name": "STREAMING_ENABLE_FORCE_CHILD_SECTOR_LOW_LOD",
+      "comment": "PC only, hash generated at runtime",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x3602DA93": {
+      "name": "STREAMING_DISABLE_FORCE_CHILD_SECTOR_LOW_LOD",
+      "comment": "PC only, hash generated at runtime",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
     "0x83E043A6": {
       "name": "RESIZE_ACTOR_SET",
       "comment": "",
@@ -49355,9 +49663,31 @@
         }
       ],
       "return_type": "int"
+    },
+    "0xD116B520": {
+      "name": "SET_RUNNING_BENCHMARK",
+      "comment": "PC only, hash generated at runtime",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x2DFDDDD9": {
+      "name": "GET_RUNNING_BENCHMARK",
+      "comment": "PC only, hash generated at runtime",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
     }
   },
-  "AI_SPEECH": {
+  "AI_SPEECH2": {
     "0xD85BAFA8": {
       "name": "SPEECH_CONTEXT_INIT_DATA",
       "comment": "",
@@ -53310,6 +53640,239 @@
     "0x21A68D47": {
       "name": "_0x21A68D47",
       "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x8291ED47": {
+      "name": "_0x8291ED47",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xB288F455": {
+      "name": "_0xB288F455",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    }
+  },
+  "PC": {
+    "0x8CF09BD7": {
+      "name": "_0x8CF09BD7",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xBAE0A3F8": {
+      "name": "_0xBAE0A3F8",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x9F832205": {
+      "name": "_0x9F832205",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xF413FDB2": {
+      "name": "_0xF413FDB2",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x63D3AAFC": {
+      "name": "_0x63D3AAFC",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x3B93B981": {
+      "name": "_0x3B93B981",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x854ACCFE": {
+      "name": "SET_HORSE_BREAK_INTRO",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xEB0F9F0C": {
+      "name": "_0xEB0F9F0C",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xFD198D8B": {
+      "name": "SET_SAVING_GAME",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xA62D75BA": {
+      "name": "SET_SAVING_GAME_ZOMBIE",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x7C730896": {
+      "name": "_0x7C730896",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x02859CE6": {
+      "name": "_0x02859CE6",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x5B47E49A": {
+      "name": "_0x5B47E49A",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x97609434": {
+      "name": "_0x97609434",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x920DB21": {
+      "name": "_0x0920DB21",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x9CED1C7E": {
+      "name": "_0x9CED1C7E",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xD9DDA7E2": {
+      "name": "_0xD9DDA7E2",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x14664FF4": {
+      "name": "SET_USING_BINOCULARS",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xB0E60B63": {
+      "name": "_0xB0E60B63",
+      "comment": "PC only",
       "params": [
         {
           "type": "Any",

--- a/natives.json
+++ b/natives.json
@@ -17322,43 +17322,43 @@
       "return_type": "void"
     },
     "0x28246500": {
-      "name": "_SET_IS_ZOMBIE_DLC_ACTIVE",
+      "name": "SET_ZOMBIE_DLC_IS_ACTIVE",
       "comment": "PS4/Switch/PC only",
       "params": [],
       "return_type": "void"
     },
     "0x8CF15FCB": {
-      "name": "_IS_ZOMBIE_DLC_ACTIVE",
+      "name": "ZOMBIE_DLC_IS_ACTIVE",
       "comment": "",
       "params": [],
       "return_type": "int"
     },
     "0x4A8066FB": {
-      "name": "_LOAD_ZOMBIE_DLC_ASSETS",
+      "name": "ZOMBIE_DLC_LOAD_ASSETS",
       "comment": "",
       "params": [],
       "return_type": "int"
     },
     "0x1DDB57A6": {
-      "name": "_LOAD_ZOMBIE_DLC_ASSETS_MP",
+      "name": "ZOMBIE_DLC_LOAD_ASSETS_MP",
       "comment": "",
       "params": [],
       "return_type": "int"
     },
     "0x88863344": {
-      "name": "_UNLOAD_ZOMBIE_DLC_ASSETS",
+      "name": "ZOMBIE_DLC_UNLOAD_ASSETS",
       "comment": "",
       "params": [],
       "return_type": "int"
     },
     "0xE7371670": {
-      "name": "_IS_ZOMBIE_DLC_LOAD_COMPLETE",
+      "name": "ZOMBIE_DLC_IS_LOAD_COMPLETE",
       "comment": "",
       "params": [],
       "return_type": "int"
     },
     "0x03E2B631": {
-      "name": "_IS_ZOMBIE_DLC_UNLOAD_COMPLETE",
+      "name": "ZOMBIE_DLC_IS_UNLOAD_COMPLETE",
       "comment": "",
       "params": [],
       "return_type": "int"
@@ -51024,7 +51024,7 @@
       "return_type": "void"
     },
     "0xB12584C8": {
-      "name": "_0xB12584C8",
+      "name": "ACCESSORIZE_VEHICLE_HORSES",
       "comment": "",
       "params": [
         {
@@ -53401,7 +53401,7 @@
       "return_type": "int"
     },
     "0xF4641CF4": {
-      "name": "_0xF4641CF4",
+      "name": "ADD_IDLEFX_TO_WEAPON",
       "comment": "",
       "params": [
         {

--- a/natives.json
+++ b/natives.json
@@ -17017,7 +17017,7 @@
       "return_type": "Any"
     },
     "0xD771AF0B": {
-      "name": "_SET_FACTION_STATUS_ONEWAY",
+      "name": "SET_FACTIONS_STATUS_ONE_WAY",
       "comment": "",
       "params": [
         {
@@ -17028,7 +17028,7 @@
       "return_type": "void"
     },
     "0x4C28B11E": {
-      "name": "_SET_FACTION_STATUS_TWOWAY",
+      "name": "SET_FACTIONS_STATUS_TWO_WAY",
       "comment": "",
       "params": [
         {
@@ -17039,7 +17039,7 @@
       "return_type": "void"
     },
     "0x6118212B": {
-      "name": "_SET_FACTIONB_STATUS_TWOWAY",
+      "name": "SET_AMBIENT_FACTIONS_STATUS_TWO_WAY",
       "comment": "",
       "params": [
         {
@@ -17050,7 +17050,7 @@
       "return_type": "void"
     },
     "0x902781BF": {
-      "name": "_0x902781BF",
+      "name": "RESET_FACTIONS_STATUS_TWO_WAY",
       "comment": "",
       "params": [
         {
@@ -17061,7 +17061,7 @@
       "return_type": "Any"
     },
     "0xF9C5DC76": {
-      "name": "_0xF9C5DC76",
+      "name": "RESET_AMBIENT_FACTIONS_STATUS_TWO_WAY",
       "comment": "",
       "params": [
         {
@@ -17747,7 +17747,7 @@
       "return_type": "int"
     },
     "0x15001332": {
-      "name": "_0x15001332",
+      "name": "FIRE_STOP_ALL_FIRES",
       "comment": "",
       "params": [],
       "return_type": "int"
@@ -17764,7 +17764,7 @@
       "return_type": "void"
     },
     "0x11A65FFB": {
-      "name": "_EXTINGUISH_FLAMES_IN_VOLUME",
+      "name": "FIRE_STOP_FLAMES_IN_VOLUME",
       "comment": "",
       "params": [
         {

--- a/natives.json
+++ b/natives.json
@@ -393,7 +393,7 @@
       "return_type": "Any"
     }
   },
-  "ACTOR": {
+  "ACTOR2": {
     "0xBA6C3E92": {
       "name": "IS_ACTOR_VALID",
       "comment": "",
@@ -2671,7 +2671,7 @@
       "return_type": "void"
     }
   },
-  "ACTORDRAW": {
+  "ENTITY": {
     "0xE6644CE5": {
       "name": "SET_DRAW_ACTOR",
       "comment": "",
@@ -2695,7 +2695,7 @@
       "return_type": "Any"
     }
   },
-  "ACTORENUM": {
+  "PED": {
     "0xD02757C1": {
       "name": "CAN_ACTOR_ENUM_PLAY_SPEECH_CONTEXT",
       "comment": "",
@@ -2766,7 +2766,7 @@
       "return_type": "int"
     }
   },
-  "ACTORINFO": {
+  "HEALTH": {
     "0x2C0F211D": {
       "name": "GET_LAST_ATTACKER",
       "comment": "",
@@ -3254,7 +3254,7 @@
       "return_type": "Any"
     }
   },
-  "AI": {
+  "AI_MISC": {
     "0x4A69F264": {
       "name": "AI_BEHAVIOR_SET_ALLOW",
       "comment": "",
@@ -4708,7 +4708,7 @@
       "return_type": "int"
     }
   },
-  "AI2": {
+  "AI_NAV": {
     "0x6ADF2927": {
       "name": "AI_CLEAR_NAV_MATERIAL_USAGE",
       "comment": "",
@@ -4994,7 +4994,7 @@
       "return_type": "int"
     }
   },
-  "AI3": {
+  "AI_PERCEPTION": {
     "0x5C580036": {
       "name": "DISABLE_VERIFY_SS",
       "comment": "",
@@ -5059,7 +5059,7 @@
       "return_type": "void"
     }
   },
-  "AI4": {
+  "AI_RIDE": {
     "0x9DDFA9CA": {
       "name": "AI_RIDING_SET_ATTRIBUTE",
       "comment": "",
@@ -5095,7 +5095,7 @@
       "return_type": "int"
     }
   },
-  "AI5": {
+  "AI_SPEECH": {
     "0xD269F20B": {
       "name": "AI_SPEECH_ADD_PHRASE",
       "comment": "",
@@ -5312,7 +5312,7 @@
       "return_type": "int"
     }
   },
-  "AMBIENT": {
+  "AI_WORLD": {
     "0xA8ADCAEB": {
       "name": "ENABLE_AMBIENT_SPAWNING",
       "comment": "",
@@ -5778,7 +5778,7 @@
       "return_type": "float*"
     }
   },
-  "AMBIENT2": {
+  "AMBIENT": {
     "0xA8226DFF": {
       "name": "AMBIENT_SET_UPDATES_ENABLED",
       "comment": "",
@@ -6817,7 +6817,7 @@
       "return_type": "int"
     }
   },
-  "ANIMAL": {
+  "AI_ANIMAL": {
     "0x5EFB415E": {
       "name": "ANIMAL_SPECIES_FLOCK_AND_TUNING_CLEAR_ALL",
       "comment": "",
@@ -13303,7 +13303,7 @@
       "return_type": "void"
     }
   },
-  "CHALLENGE": {
+  "SOCIALCLUB": {
     "0x1EB9AF29": {
       "name": "UI_CHALLENGE_CREATE",
       "comment": "",
@@ -13580,7 +13580,7 @@
       "return_type": "void"
     }
   },
-  "COMBAT": {
+  "AI_COMBAT": {
     "0x13FA7128": {
       "name": "COMBAT_CLASS_AI_CLEAR_ALL_ATTRIBS",
       "comment": "",
@@ -13985,7 +13985,7 @@
       "return_type": "int"
     }
   },
-  "CURVE": {
+  "CURVES": {
     "0x0C46DAB3": {
       "name": "ENABLE_CURVE",
       "comment": "",
@@ -14985,7 +14985,7 @@
       "return_type": "void"
     }
   },
-  "DECAL": {
+  "FX": {
     "0xA5A6A3E3": {
       "name": "ENABLE_PIP",
       "comment": "",
@@ -16084,6 +16084,17 @@
         }
       ],
       "return_type": "BOOL"
+    },
+    "0x2F78AEFA": {
+      "name": "_0x2F78AEFA",
+      "comment": "PS4/Switch/PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
     }
   },
   "DOOR": {
@@ -16356,7 +16367,7 @@
       "return_type": "BOOL"
     }
   },
-  "ELEMENT": {
+  "PPPELEMENTS": {
     "0x598815BD": {
       "name": "_0x598815BD",
       "comment": "",
@@ -17127,7 +17138,7 @@
       "return_type": "void"
     }
   },
-  "FACTION2": {
+  "AI_VISION": {
     "0x656D3D26": {
       "name": "CAN_ANYONE_OF_FACTION_SEE_OBJECT",
       "comment": "",
@@ -17144,7 +17155,7 @@
       "return_type": "BOOL"
     }
   },
-  "FIRE": {
+  "WORLD": {
     "0x9A93E7CA": {
       "name": "CLEAR_AREA_OF_TREE_TYPE",
       "comment": "",
@@ -17307,6 +17318,12 @@
     "0xDCAE6935": {
       "name": "RELOAD_SMICTIONARY_LIST",
       "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x28246500": {
+      "name": "_0x28246500",
+      "comment": "PS4/Switch/PC only",
       "params": [],
       "return_type": "void"
     },
@@ -17578,6 +17595,12 @@
           "name": "p0"
         }
       ],
+      "return_type": "int"
+    },
+    "0xE437932A": {
+      "name": "_0xE437932A",
+      "comment": "PS4/Switch/PC only",
+      "params": [],
       "return_type": "int"
     },
     "0xBBAE9CBD": {
@@ -17950,7 +17973,7 @@
       "return_type": "int"
     }
   },
-  "GAME": {
+  "CORE": {
     "0x505A8057": {
       "name": "SET_DEBUG_DRAW",
       "comment": "",
@@ -19025,7 +19048,7 @@
       "return_type": "int"
     },
     "0xBEC2871A": {
-      "name": "_0xBEC2871A",
+      "name": "GET_TIME_SINCE_LAST_MOVESTICK_INPUT",
       "comment": "",
       "params": [
         {
@@ -19574,6 +19597,18 @@
       "params": [],
       "return_type": "BOOL"
     },
+	"0x99989FCD": {
+      "name": "IS_PS4",
+      "comment": "PS4/Switch/PC only",
+      "params": [],
+      "return_type": "BOOL"
+    },
+	"0x92E03425": {
+      "name": "IS_SWITCH",
+      "comment": "PS4/Switch/PC only",
+      "params": [],
+      "return_type": "BOOL"
+    },
     "0xB427CB25": {
       "name": "_0xB427CB25",
       "comment": "",
@@ -19684,6 +19719,39 @@
         }
       ],
       "return_type": "int"
+    },
+    "0x81A7CDB6": {
+      "name": "_0x81A7CDB6",
+      "comment": "PS4/Switch/PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x2A04518E": {
+      "name": "_0x2A04518E",
+      "comment": "PS4/Switch/PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x4FC61E5F": {
+      "name": "_0x4FC61E5F",
+      "comment": "PS4/Switch/PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
     },
     "0x3B417D4E": {
       "name": "SET_MISSION_INFO",
@@ -19826,6 +19894,12 @@
       "params": [],
       "return_type": "BOOL"
     },
+    "0xD90DB78D": {
+      "name": "IS_D11_CUTSCENE_HACK",
+      "comment": "",
+      "params": [],
+      "return_type": "BOOL"
+    },
     "0x554FC5E0": {
       "name": "IS_DISPLAY_WIDESCREEN",
       "comment": "",
@@ -19856,7 +19930,7 @@
       "return_type": "int"
     }
   },
-  "GAMERTAG": {
+  "GRAVESTONE": {
     "0xF62EE158": {
       "name": "_0xF62EE158",
       "comment": "",
@@ -20075,7 +20149,7 @@
       "return_type": "Any"
     }
   },
-  "GOHEVENT": {
+  "AI_ATTENTION": {
     "0x945F518F": {
       "name": "_AIATTENTIONATTRACTOR",
       "comment": "",
@@ -25482,7 +25556,7 @@
       "return_type": "void"
     }
   },
-  "INTERSECTION": {
+  "WORLD2": {
     "0x9CD3AD70": {
       "name": "FIND_INTERSECTION",
       "comment": "",
@@ -26785,7 +26859,7 @@
       "return_type": "Any"
     }
   },
-  "LAYOUT": {
+  "OBJECT": {
     "0x0B396DFF": {
       "name": "VERIFY_TYPE_COUNT",
       "comment": "",
@@ -33190,7 +33264,7 @@
       "return_type": "int"
     }
   },
-  "MEMORY": {
+  "AI_MEMORY": {
     "0x8CD37E9E": {
       "name": "MEMORY_CLEAR_EVENTS",
       "comment": "",
@@ -33874,7 +33948,7 @@
       "return_type": "int"
     }
   },
-  "MOUNT": {
+  "RIDING": {
     "0x00AF2CB0": {
       "name": "SET_MOST_RECENT_MOUNT",
       "comment": "",
@@ -34187,7 +34261,7 @@
       "return_type": "void"
     }
   },
-  "MOVABLE": {
+  "NAVMESH": {
     "0x8A0D3339": {
       "name": "STREAMING_IS_MOVABLE_NAV_MESH_RESIDENT",
       "comment": "",
@@ -34236,13 +34310,19 @@
   "MOVIE": {
     "0x92028B49": {
       "name": "WORLD_MOVIE_PLAYER",
-      "comment": "",
+      "comment": "Not in PS4/Switch/PC",
       "params": [
         {
           "type": "Any",
           "name": "p0"
         }
       ],
+      "return_type": "int"
+    },
+	"0x7614AEBA": {
+      "name": "_0x7614AEBA",
+      "comment": "PS4/Switch/PC only",
+      "params": [],
       "return_type": "int"
     },
     "0x69FC319E": {
@@ -34258,7 +34338,7 @@
       "return_type": "int"
     }
   },
-  "MOVIE2": {
+  "MOTIVE": {
     "0x1BED8493": {
       "name": "SET_MOTIVE_BY_ENUM",
       "comment": "",
@@ -34279,7 +34359,7 @@
       "return_type": "int"
     }
   },
-  "MUSIC": {
+  "AMBIENCE": {
     "0x2A3B1045": {
       "name": "AMBIENCE_AUDIO_ENTITY_UPDATE_TERRITORY",
       "comment": "",
@@ -34322,7 +34402,7 @@
       "return_type": "int"
     }
   },
-  "NAV": {
+  "NAVQUERY": {
     "0xE2F41226": {
       "name": "CREATE_NAV_QUERY",
       "comment": "",
@@ -35835,6 +35915,12 @@
       "comment": "",
       "params": [],
       "return_type": "int*"
+    },
+    "0x489A2B93": {
+      "name": "_0x489A2B93",
+      "comment": "PS4/Switch/PC only",
+      "params": [],
+      "return_type": "int*"
     }
   },
   "NET2": {
@@ -35947,7 +36033,7 @@
       "return_type": "int"
     }
   },
-  "NET3": {
+  "NET_STATS": {
     "0x12304873": {
       "name": "NET_UPDATE_LEADERBOARD",
       "comment": "",
@@ -36202,7 +36288,7 @@
       "return_type": "int"
     }
   },
-  "NET4": {
+  "NET_UI": {
     "0x8808546E": {
       "name": "NET_GET_AND_CLEAR_GAME_MODE_REQUEST",
       "comment": "",
@@ -36823,7 +36909,7 @@
       "return_type": "int"
     }
   },
-  "NETCONNECTION": {
+  "PLAYSTATS": {
     "0x2547029C": {
       "name": "_0x2547029C",
       "comment": "",
@@ -37718,7 +37804,7 @@
       "return_type": "int"
     }
   },
-  "PHYSINST2": {
+  "MISC": {
     "0x11069324": {
       "name": "CREATE_OBJECT_LOCATOR",
       "comment": "",
@@ -37890,7 +37976,7 @@
       "return_type": "int"
     }
   },
-  "PLAYER": {
+  "ACTOR": {
     "0x2D54B916": {
       "name": "TELEPORT_ACTOR",
       "comment": "",
@@ -40733,7 +40819,7 @@
       "return_type": "int"
     }
   },
-  "PROBE": {
+  "OBJECT2": {
     "0x7080E24A": {
       "name": "_0x7080E24A",
       "comment": "",
@@ -41215,9 +41301,20 @@
         }
       ],
       "return_type": "void"
+    },
+    "0x09D4CDEF": {
+      "name": "_0x09D4CDEF",
+      "comment": "PS4/Switch/PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
     }
   },
-  "RETICLE": {
+  "TARGETING": {
     "0x86BAAC6C": {
       "name": "GET_ACTOR_UNDER_RETICLE",
       "comment": "",
@@ -42122,7 +42219,7 @@
       "return_type": "int"
     }
   },
-  "SIMULATOR": {
+  "PHYSICS": {
     "0x17B69196": {
       "name": "GET_PHYSINST_VELOCITY",
       "comment": "",
@@ -42305,7 +42402,7 @@
       "return_type": "int"
     }
   },
-  "SOCIALCLUB": {
+  "GAME": {
     "0x6FCF6BC8": {
       "name": "DISABLE_PLAYER_GRINGO_USE",
       "comment": "",
@@ -42863,7 +42960,7 @@
       "return_type": "Any"
     }
   },
-  "SQUAD": {
+  "SQUADS": {
     "0xB3732081": {
       "name": "SQUAD_GET",
       "comment": "",
@@ -44776,7 +44873,7 @@
       "return_type": "int"
     }
   },
-  "STREAMING": {
+  "STREAM": {
     "0xB0A79FEE": {
       "name": "STREAMING_REQUEST_ACTOR",
       "comment": "",
@@ -45709,7 +45806,7 @@
       "return_type": "int"
     }
   },
-  "TASK": {
+  "TASKS": {
     "0xE32F09B3": {
       "name": "TASK_ACTION_PERFORM",
       "comment": "",
@@ -49260,7 +49357,7 @@
       "return_type": "int"
     }
   },
-  "UNK": {
+  "AI_SPEECH": {
     "0xD85BAFA8": {
       "name": "SPEECH_CONTEXT_INIT_DATA",
       "comment": "",
@@ -49460,7 +49557,7 @@
       "return_type": "void"
     }
   },
-  "UNK2": {
+  "GREETING": {
     "0x9953D4FC": {
       "name": "SET_GREETING_CONTEXT",
       "comment": "",
@@ -49613,7 +49710,7 @@
       "return_type": "void"
     }
   },
-  "UNK3": {
+  "AI_CONVERSE": {
     "0x30402375": {
       "name": "AI_CONVERSE_SET_GREETING_CONTEXT",
       "comment": "",
@@ -49882,7 +49979,7 @@
       "return_type": "Any"
     }
   },
-  "UNK4": {
+  "PLAYERNAMES": {
     "0x77D6ABF5": {
       "name": "NET_GAMER_SET_ACTOR_OVERRIDE",
       "comment": "",
@@ -50243,7 +50340,7 @@
       "return_type": "int"
     }
   },
-  "VEHICLE": {
+  "VEHICLES": {
     "0x58745E4B": {
       "name": "GET_ACTOR_MOST_RECENT_VEHICLE",
       "comment": "",
@@ -51248,7 +51345,7 @@
       "return_type": "Any"
     }
   },
-  "VEHICLEWEAPON": {
+  "TURRET": {
     "0x2C5983E0": {
       "name": "IS_USING_TURRET",
       "comment": "",
@@ -51436,7 +51533,7 @@
       "return_type": "int"
     }
   },
-  "WEAPON": {
+  "INVENTORY": {
     "0xBAA5D41B": {
       "name": "ADD_ITEM",
       "comment": "",
@@ -52565,7 +52662,7 @@
       "return_type": "Any"
     }
   },
-  "WEAPONENUM": {
+  "WEAPON": {
     "0xBAC27559": {
       "name": "_WEAPON_ENUM_PISTOL",
       "comment": "",

--- a/natives.json
+++ b/natives.json
@@ -1,40 +1,233 @@
 {
-  "SYSTEM": {
-    "0x7715C03B": {
-      "name": "WAIT",
+  "ACTOR": {
+    "0x2D54B916": {
+      "name": "TELEPORT_ACTOR",
       "comment": "",
       "params": [
         {
-          "type": "int",
-          "name": "ms"
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "float",
+          "name": "x"
+        },
+        {
+          "type": "float",
+          "name": "y"
+        },
+        {
+          "type": "float",
+          "name": "z"
+        },
+        {
+          "type": "BOOL",
+          "name": "p4"
+        },
+        {
+          "type": "BOOL",
+          "name": "p5"
+        },
+        {
+          "type": "BOOL",
+          "name": "p6"
         }
       ],
       "return_type": "void"
     },
-    "0x01185F9B": {
-      "name": "WAITUNWARPED",
+    "0xE4DE507C": {
+      "name": "TELEPORT_ACTOR_WITH_HEADING",
       "comment": "",
       "params": [
         {
-          "type": "int",
-          "name": "ms"
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "float",
+          "name": "x"
+        },
+        {
+          "type": "float",
+          "name": "y"
+        },
+        {
+          "type": "float",
+          "name": "z"
+        },
+        {
+          "type": "float",
+          "name": "heading"
+        },
+        {
+          "type": "BOOL",
+          "name": "p5"
+        },
+        {
+          "type": "BOOL",
+          "name": "p6"
+        },
+        {
+          "type": "BOOL",
+          "name": "p7"
         }
       ],
       "return_type": "void"
     },
-    "0x7C496803": {
-      "name": "WAITUNPAUSED",
+    "0x6B3A39A9": {
+      "name": "GET_MAX_SPEED",
       "comment": "",
       "params": [
         {
-          "type": "int",
-          "name": "ms"
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x99BD9D6F": {
+      "name": "GET_POSITION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "float*",
+          "name": "x"
+        },
+        {
+          "type": "float*",
+          "name": "y"
+        },
+        {
+          "type": "float*",
+          "name": "z"
         }
       ],
       "return_type": "void"
     },
-    "0x3F166D0E": {
-      "name": "START_NEW_SCRIPT",
+    "0x42DE39F0": {
+      "name": "GET_HEADING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0x294A5549": {
+      "name": "GET_ACTOR_AXIS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xECE8520B": {
+      "name": "SET_ACTOR_HEADING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "float",
+          "name": "heading"
+        },
+        {
+          "type": "BOOL",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xCDC686B2": {
+      "name": "SET_ACTOR_ONE_SHOT_DEATH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "BOOL",
+          "name": "toggle"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0912622D": {
+      "name": "GET_ACTOR_ONE_SHOT_DEATH_STATUS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x758F993A": {
+      "name": "GET_PHYSINST_FROM_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "int*",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x1AA3A0C0": {
+      "name": "CAN_ACTOR_HOGTIE_TARGET",
       "comment": "",
       "params": [
         {
@@ -46,10 +239,697 @@
           "name": "p1"
         }
       ],
+      "return_type": "int"
+    },
+    "0xB27E91E7": {
+      "name": "IS_ACTOR_PLAYER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x6542CF26": {
+      "name": "IS_ACTOR_LOCAL_PLAYER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xB114332D": {
+      "name": "_PUSH_NEG_ONE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x524F6981": {
+      "name": "_GET_ACTOR_CONTROLLER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xCF02D1D6": {
+      "name": "_0xCF02D1D6",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x8F82B7D4": {
+      "name": "_0x8F82B7D4",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC733BC9A": {
+      "name": "SET_ENABLE_NAV_STICK_INPUT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xD17AFCD8": {
+      "name": "SET_PLAYER_CONTROL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "BOOL",
+          "name": "toggle"
+        },
+        {
+          "type": "int",
+          "name": "possiblyFlags"
+        },
+        {
+          "type": "BOOL",
+          "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xBEEDDD54": {
+      "name": "SET_PLAYER_ENABLE_MOUNT_USE_CONTEXTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "BOOL",
+          "name": "toggle"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xEA08A934": {
+      "name": "SET_PLAYER_ALLOW_PICKUP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xAC1285A3": {
+      "name": "SET_PLAYER_MELEE_MODE_SELECTED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "int",
+          "name": "mode"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0959C27A": {
+      "name": "SET_PLAYER_DISABLE_TARGETING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x9613C2D0": {
+      "name": "_0x9613C2D0",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x6576AD43": {
+      "name": "IS_PLAYER_IN_COMBAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x48B7C279": {
+      "name": "IS_PLAYER_IN_COMBAT_WITHIN",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xCE7CE46D": {
+      "name": "SET_RETICLE_DRAW_DISABLED_BY_SCRIPT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x4590CE00": {
+      "name": "SET_PLAYER_CONTROL_RUMBLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Player",
+          "name": "player"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xB3BE2F95": {
+      "name": "RESET_RUMBLE",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x8421033D": {
+      "name": "GET_PLAYER_CONTROL_CONFIG",
+      "comment": "",
+      "params": [
+        {
+          "type": "Player",
+          "name": "player"
+        }
+      ],
       "return_type": "Any"
     },
-    "0x4A2100E4": {
-      "name": "START_NEW_SCRIPT_WITH_ARGS",
+    "0x01B84BCA": {
+      "name": "SET_PLAYER_CONTROL_CONFIG",
+      "comment": "",
+      "params": [
+        {
+          "type": "Player",
+          "name": "player"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x2E0EC2F2": {
+      "name": "PLAYER_RUMBLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4B0D6152": {
+      "name": "SET_PLAYER_CURRENT_NOTORIETY",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x4D918005": {
+      "name": "SET_PLAYER_CURRENT_HONOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x57595189": {
+      "name": "SET_PLAYER_COMBATMODE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Player",
+          "name": "player"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x86E193B8": {
+      "name": "GET_PLAYER_COMBATMODE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xAFFBBE78": {
+      "name": "SET_PLAYER_COMBATMODE_OVERRIDE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Player",
+          "name": "player"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x1184EC7B": {
+      "name": "SET_PLAYER_COMBATMODE_EXCLUSION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE1160B04": {
+      "name": "SET_PLAYER_VEHICLE_INPUT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Player",
+          "name": "player"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x900165CE": {
+      "name": "ADD_PLAYER_CONTROL_HORSE_FOLLOW",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xBFC8EF7C": {
+      "name": "REM_PLAYER_CONTROL_HORSE_FOLLOW",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7C522386": {
+      "name": "CLEAR_PLAYER_CONTROL_HORSE_FOLLOW",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE44DCE87": {
+      "name": "IS_PLAYER_IN_HORSE_FOLLOW",
+      "comment": "",
+      "params": [
+        {
+          "type": "Player",
+          "name": "player"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xE8CFDD53": {
+      "name": "GET_PLAYER_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Player",
+          "name": "player"
+        }
+      ],
+      "return_type": "Actor"
+    },
+    "0x40EF1003": {
+      "name": "IS_LOCAL_PLAYER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x0ADC17E9": {
+      "name": "IS_LOCAL_PLAYER_VALID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xD04480FE": {
+      "name": "IS_SLOT_VALID",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "slot"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xDB9B49D8": {
+      "name": "GET_SLOT_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xAABF3356": {
+      "name": "GET_ACTOR_SLOT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xAD68A22E": {
+      "name": "GET_LOCAL_SLOT",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x34CBABAE": {
+      "name": "GET_SLOT_NAME",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "slot"
+        }
+      ],
+      "return_type": "const char*"
+    },
+    "0x3241158C": {
+      "name": "GET_SLOT_POSITION",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "slot"
+        },
+        {
+          "type": "float*",
+          "name": "x"
+        },
+        {
+          "type": "float*",
+          "name": "y"
+        },
+        {
+          "type": "float*",
+          "name": "z"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x34A9866B": {
+      "name": "GET_SLOT_FACING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x87DDCA96": {
+      "name": "IS_PLAYER_TARGETTING_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x622796D5": {
+      "name": "IS_PLAYER_TARGETTING_OBJECT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x6148423A": {
+      "name": "IS_PLAYER_DEADEYE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xB6A47C37": {
+      "name": "SET_PLAYER_DEADEYE_MODE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x1CFAF2EA": {
+      "name": "SET_FORCE_PLAYER_AIM_MODE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xD0E08B5E": {
+      "name": "SET_PLAYER_ENDLESS_READYMODE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xBC521A38": {
+      "name": "GET_PLAYER_ZOOM_STATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x724A2931": {
+      "name": "IS_PLAYER_USING_COVER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x45F2A70A": {
+      "name": "ATTACH_PLAYER_TO_COVER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0D77CC34": {
+      "name": "SIMULATE_PLAYER_INPUT_GAIT",
       "comment": "",
       "params": [
         {
@@ -69,111 +949,29 @@
           "name": "p3"
         }
       ],
-      "return_type": "Any"
+      "return_type": "void"
     },
-    "0x35785333": {
-      "name": "SETTIMERA",
+    "0xEAE75C6F": {
+      "name": "ACTOR_POP_NEXT_GAIT",
       "comment": "",
       "params": [
         {
           "type": "Any",
           "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x50597EE2": {
-      "name": "TIMESTEP",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0xECF8EB5F": {
-      "name": "PRINTSTRING",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "value"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xD48B90B6": {
-      "name": "PRINTFLOAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "value"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x63651F03": {
-      "name": "PRINTINT",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "value"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x868997DA": {
-      "name": "PRINTNL",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x85F31FB": {
-      "name": "PRINTVECTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
         },
         {
-          "type": "float",
+          "type": "Any",
           "name": "p1"
         },
         {
-          "type": "float",
+          "type": "Any",
           "name": "p2"
         }
       ],
       "return_type": "void"
     },
-    "0x145C7701": {
-      "name": "SQRT",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "value"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0x85D134F8": {
-      "name": "POW",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "base"
-        },
-        {
-          "type": "float",
-          "name": "exponent"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0xE2313450": {
-      "name": "EXP",
+    "0x1ABFBFA3": {
+      "name": "ACTOR_SET_MAX_GAIT",
       "comment": "",
       "params": [
         {
@@ -185,171 +983,1175 @@
           "name": "p1"
         }
       ],
-      "return_type": "Any"
+      "return_type": "int"
     },
-    "0x1FCF1ECD": {
-      "name": "VMAG",
+    "0xD39C4A9E": {
+      "name": "IS_ACTOR_USING_COVER",
       "comment": "",
       "params": [
         {
-          "type": "float",
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xEBBE1CAC": {
+      "name": "IS_ACTOR_USING_LEDGE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x50D8C840": {
+      "name": "SET_PLAYER_DEADEYE_POINTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
           "name": "p0"
         },
         {
-          "type": "float",
+          "type": "Any",
           "name": "p1"
         },
         {
-          "type": "float",
+          "type": "Any",
           "name": "p2"
         }
       ],
-      "return_type": "float"
-    },
-    "0x3C08ECB7": {
-      "name": "VDIST",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "x1"
-        },
-        {
-          "type": "float",
-          "name": "y1"
-        },
-        {
-          "type": "float",
-          "name": "z1"
-        },
-        {
-          "type": "float",
-          "name": "x2"
-        },
-        {
-          "type": "float",
-          "name": "y2"
-        },
-        {
-          "type": "float",
-          "name": "z2"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0xC85DEF1F": {
-      "name": "VDIST2",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "x1"
-        },
-        {
-          "type": "float",
-          "name": "y1"
-        },
-        {
-          "type": "float",
-          "name": "z1"
-        },
-        {
-          "type": "float",
-          "name": "x2"
-        },
-        {
-          "type": "float",
-          "name": "y2"
-        },
-        {
-          "type": "float",
-          "name": "z2"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0x314CC6CD": {
-      "name": "SHIFT_LEFT",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "value"
-        },
-        {
-          "type": "int",
-          "name": "bitShift"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x352633CA": {
-      "name": "SHIFT_RIGHT",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "value"
-        },
-        {
-          "type": "int",
-          "name": "bitShift"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x32E9BE04": {
-      "name": "FLOOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "value"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xD536A1DF": {
-      "name": "CEIL",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "value"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x323B0E24": {
-      "name": "ROUND",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "value"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x67116627": {
-      "name": "TO_FLOAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "value"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0x5A25520E": {
-      "name": "SNAPSHOT_GLOBALS",
-      "comment": "",
-      "params": [],
       "return_type": "void"
     },
-    "0x2B547FE6": {
-      "name": "GET_LATEST_CONSOLE_COMMAND",
+    "0xE2C4AEE7": {
+      "name": "ADD_PLAYER_DEADEYE_POINTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x86B5C9E1": {
+      "name": "GET_PLAYER_DEADEYE_POINTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x09716951": {
+      "name": "SET_DISABLE_DEADEYE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0486955B": {
+      "name": "SET_DEADEYE_POINT_MODIFIER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x526D45B7": {
+      "name": "SET_MAX_DEADEYE_POINTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4E6E5E78": {
+      "name": "SET_DEADEYE_MULTILOCK_ENABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x5CD6E2C3": {
+      "name": "SET_DEADEYE_TARGETPAINT_ENABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xA671FF8E": {
+      "name": "SET_DEADEYE_INVULNERABILITY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0D583DAF": {
+      "name": "SET_DEADEYE_DAMAGE_SCALING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x863F0193": {
+      "name": "SET_DEADEYE_TIME_LIMIT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x0415EE4C": {
+      "name": "SET_DEADEYE_REGENERATION_RATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "float",
+          "name": "rate"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x151741A2": {
+      "name": "SET_DEADEYE_REGENERATION_RATE_MULTIPLIER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x5740CDC2": {
+      "name": "SET_DEADEYE_TIMESCALE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0C0BC04E": {
+      "name": "SET_INFINITE_DEADEYE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "BOOL",
+          "name": "toggle"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7F454A92": {
+      "name": "_0x7F454A92",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0xFA8D2B69": {
+      "name": "SET_WAGON_TO_WAGON_JACK_ENABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x3BD4426B": {
+      "name": "SET_PLAYER_POSTURE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xC550644A": {
+      "name": "SET_ACTOR_ALLOW_DISMOUNT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE38EF526": {
+      "name": "SET_ACTOR_INVULNERABILITY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "BOOL",
+          "name": "toggle"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xDB39D992": {
+      "name": "GET_ACTOR_INVULNERABILITY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x2A575132": {
+      "name": "SET_TOUGH_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "BOOL",
+          "name": "toggle"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0D9A35F6": {
+      "name": "SET_ACTOR_UNKILLABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "BOOL",
+          "name": "toggle"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xB4CD475D": {
+      "name": "SET_ACTOR_PERMANENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x731F2C21": {
+      "name": "SET_ACTOR_PERMANENT_DEAD",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xED89D0E0": {
+      "name": "SET_ACTOR_FROZEN_AFTER_CORPSIFY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xF5B74E20": {
+      "name": "CLEAR_ACTOR_PROOF",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x9E7AE28B": {
+      "name": "CLEAR_ACTOR_PROOF_ALL",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "result"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x147EA072": {
+      "name": "GET_ACTOR_PROOF",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xA5875DC8": {
+      "name": "SET_ACTOR_PROOF",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xF2F77F44": {
+      "name": "SET_ACTOR_OVERHEALTH_MODE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x437588E6": {
+      "name": "_REPAIR_INCAPACITATION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xEE4E2461": {
+      "name": "GET_ACTOR_INCAPACITATED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x2D9C0C0F": {
+      "name": "SET_ALLOW_RIDE_BY_AI",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0318FF2A": {
+      "name": "GET_ALLOW_RIDE_BY_PLAYER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xCF1A1BC5": {
+      "name": "SET_ALLOW_RIDE_BY_PLAYER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "BOOL",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xF83A8D2B": {
+      "name": "SET_ALLOW_RIDE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x0111E8E0": {
+      "name": "GET_ALLOW_RIDE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x5D5BD1F0": {
+      "name": "SET_ALLOW_JACK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x5896817B": {
+      "name": "SET_ALLOW_EXECUTE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xA1BFC1A5": {
+      "name": "SET_ALLOW_DEADEYE_LOCKS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x9375946B": {
+      "name": "SET_DEADEYE_LOCKS_ON_HEAD_ONLY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x740B78A8": {
+      "name": "SET_ALLOW_MELEE_SPECIAL_MOVE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7A11D611": {
+      "name": "SET_ALLOW_LASSO_MINI_GAME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x0666B436": {
+      "name": "ACTOR_DISMOUNT_NOW",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xBFD6AE3D": {
+      "name": "IS_ACTOR_REACTING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x6D322CD3": {
+      "name": "GET_ACTOR_UPDATE_PRIORITY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x44C05EF6": {
+      "name": "SET_ACTOR_UPDATE_PRIORITY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xA4E29C31": {
+      "name": "_0xA4E29C31",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5C7F63E3": {
+      "name": "ACTOR_FORCE_NEXT_UPDATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x87C49DBD": {
+      "name": "IS_ANY_ACTOR_IN_SPHERE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xB42EBC65": {
+      "name": "SET_NPC_TO_NPC_CRIPPLE_DISABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "result"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x135EA21D": {
+      "name": "SET_NPC_TO_NPC_DAMAGE_SCALE_FACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "float*"
+    },
+    "0xA393AC4E": {
+      "name": "SET_PLAYER_TO_PLAYER_DAMAGE_SCALE_FACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "float*"
+    },
+    "0x05CFE1E9": {
+      "name": "SET_NPC_TO_ACTOR_DAMAGE_SCALE_FACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x083903D1": {
+      "name": "SET_ACTOR_LOW_DROP_DAMAGE",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x1540A309": {
+      "name": "SET_ACTOR_MEDIUM_DROP_DAMAGE",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "p0"
+        },
+        {
+          "type": "int",
+          "name": "p1"
+        },
+        {
+          "type": "int",
+          "name": "p2"
+        },
+        {
+          "type": "int",
+          "name": "p3"
+        },
+        {
+          "type": "int",
+          "name": "p4"
+        },
+        {
+          "type": "int",
+          "name": "p5"
+        },
+        {
+          "type": "int",
+          "name": "p6"
+        },
+        {
+          "type": "int",
+          "name": "p7"
+        },
+        {
+          "type": "float",
+          "name": "p8"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7CC57FDA": {
+      "name": "SET_ACTOR_HIGH_DROP_DAMAGE",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "p0"
+        },
+        {
+          "type": "int",
+          "name": "p1"
+        },
+        {
+          "type": "int",
+          "name": "p2"
+        },
+        {
+          "type": "int",
+          "name": "p3"
+        },
+        {
+          "type": "int",
+          "name": "p4"
+        },
+        {
+          "type": "int",
+          "name": "p5"
+        },
+        {
+          "type": "int",
+          "name": "p6"
+        },
+        {
+          "type": "int",
+          "name": "p7"
+        },
+        {
+          "type": "float",
+          "name": "p8"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x9F6B04C8": {
+      "name": "SET_ACTOR_DEATH_DROP_DISTANCE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xDA0CDC91": {
+      "name": "SET_DAMAGE_SCALE_ENABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x3AD31762": {
+      "name": "SET_CRIPPLE_ENABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0A9A99DF": {
+      "name": "SET_CRIPPLE_FLAG",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x38C5F63F": {
+      "name": "IS_ACTOR_CRIPPLED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xA5A24484": {
+      "name": "IS_ACTOR_HANDSUP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xA4677DD2": {
+      "name": "SET_ALLOW_COLD_WEATHER_BREATH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x1F0CD262": {
+      "name": "SET_DLC_FALLBACK_AVATAR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x1D1D9387": {
+      "name": "SET_EMOTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xC0F77310": {
+      "name": "SET_ACTOR_STOP_UPDATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x4EFC58BC": {
+      "name": "GET_ACTOR_STOP_UPDATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x22558E3F": {
+      "name": "IS_ACTOR_IN_ROOM",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x398735FA": {
+      "name": "REGISTER_TRAFFIC_OBJECTSET",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x67FA18A1": {
+      "name": "REGISTER_TRAFFIC_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x1444F022": {
+      "name": "REGISTER_GPS_CURVE_OBJECTSET",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4B90D22A": {
+      "name": "SET_PLAYER_TARGET_WEIGHT",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "float*"
+    },
+    "0xF1779E65": {
+      "name": "RESET_PLAYER_TARGET_WEIGHT",
+      "comment": "",
+      "params": [],
+      "return_type": "float*"
+    },
+    "0xA819497B": {
+      "name": "SET_HARDLOCK_TARGET_ANGLE_WEIGHTING",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int*"
+    },
+    "0x8BE2D8B0": {
+      "name": "SET_ZOMBIE_TARGET_MODE",
       "comment": "",
       "params": [
         {
@@ -359,9 +2161,46 @@
       ],
       "return_type": "Any"
     },
-    "0xAA3EC981": {
-      "name": "RESET_LATEST_CONSOLE_COMMAND",
+    "0x91BB8548": {
+      "name": "SET_ACTOR_SKIP_VISIBILITY_CHECK",
       "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8AE58EE1": {
+      "name": "GET_ACTOR_SKIP_VISIBILITY_CHECK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xDE0E96F3": {
+      "name": "FEED_CODE_WARP_DIST",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x968F0317": {
+      "name": "_0x968F0317",
+      "comment": "PC only",
       "params": [
         {
           "type": "Any",
@@ -370,27 +2209,20 @@
       ],
       "return_type": "Any"
     },
-    "0x9DE3DE24": {
-      "name": "GET_CONSOLE_COMMAND_TOKEN",
+    "0x0911BA31": {
+      "name": "SET_ACTOR_STREAMING_HIGH_PRIORITY",
       "comment": "",
       "params": [
         {
           "type": "Any",
           "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x608F5BC6": {
-      "name": "GET_NUM_CONSOLE_COMMAND_TOKENS",
-      "comment": "",
-      "params": [
+        },
         {
           "type": "Any",
-          "name": "p0"
+          "name": "p1"
         }
       ],
-      "return_type": "Any"
+      "return_type": "int"
     }
   },
   "ACTOR2": {
@@ -2671,453 +4503,6 @@
       "return_type": "void"
     }
   },
-  "ENTITY": {
-    "0xE6644CE5": {
-      "name": "SET_DRAW_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x085A9CA6": {
-      "name": "GET_DRAW_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    }
-  },
-  "PED": {
-    "0xD02757C1": {
-      "name": "CAN_ACTOR_ENUM_PLAY_SPEECH_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x886E06C2": {
-      "name": "REGISTER_ACTOR_SPEECH_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "const char*",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        }
-      ],
-      "return_type": "int*"
-    },
-    "0xB6839756": {
-      "name": "FINISH_REGISTERING_ACTOR_SPEECH_CONTEXTS",
-      "comment": "",
-      "params": [],
-      "return_type": "int*"
-    },
-    "0xCB139D15": {
-      "name": "REGISTER_NUM_SPEECH_CONTEXTS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "const char*"
-    },
-    "0xF07F5E41": {
-      "name": "REGISTER_NUM_CONTEXT_TYPES",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    }
-  },
-  "HEALTH": {
-    "0x2C0F211D": {
-      "name": "GET_LAST_ATTACKER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x3A207AF2": {
-      "name": "GET_LAST_HIT_TIME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x07B7AA6B": {
-      "name": "GET_LAST_HIT_WEAPON",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x08308EBA": {
-      "name": "GET_LAST_HIT_FLAGS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x45556269": {
-      "name": "GET_LAST_DAMAGE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x855F9A3B": {
-      "name": "GET_LAST_HIT_ZONE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any*",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x4747F219": {
-      "name": "GET_CORPSE_LAST_HIT_WEAPON",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0xF75FE17F": {
-      "name": "GET_CORPSE_LAST_HIT_ZONE",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x8D696237": {
-      "name": "CLEAR_LAST_HIT",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x8B08ECA2": {
-      "name": "KILL_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x6085F7AC": {
-      "name": "KILL_ACTOR_WITH_KILLER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x2F232639": {
-      "name": "IS_ACTOR_ALIVE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x0D798FFE": {
-      "name": "IS_ACTOR_DEAD",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x3918D335": {
-      "name": "IS_ACTOR_RAGDOLL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xFA090024": {
-      "name": "SET_ACTOR_HEALTH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "float",
-          "name": "health"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xF246F15D": {
-      "name": "GET_ACTOR_HEALTH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0xB69A84AF": {
-      "name": "GET_ACTOR_MAX_HEALTH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0x165BD4C5": {
-      "name": "SET_ACTOR_MAX_HEALTH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x7A207FFE": {
-      "name": "_0x7A207FFE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x3A2D7759": {
-      "name": "SET_ACTOR_KO_POINTS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x44787A58": {
-      "name": "GET_ACTOR_KO_POINTS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xAFC96669": {
-      "name": "GET_ACTOR_MAX_KO_POINTS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x4EEC6628": {
-      "name": "_SET_ACTOR_HEALTH_3",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x479B997B": {
-      "name": "_SET_ACTOR_HEALTH_4",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xFF07D58C": {
-      "name": "IS_ACTOR_DRUNK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x9F57742C": {
-      "name": "SET_ACTOR_DRUNK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "BOOL",
-          "name": "toggle"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x2A9FD09F": {
-      "name": "SET_ACTOR_PASSED_OUT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x5262C0F7": {
-      "name": "SET_ACTOR_HANGING_FROM_NOOSE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x6287203C": {
-      "name": "_0x6287203C",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x1082715D": {
-      "name": "_0x1082715D",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    }
-  },
   "ACTORSET": {
     "0x009DFC82": {
       "name": "CREATE_ACTORSET_IN_LAYOUT",
@@ -3252,6 +4637,1992 @@
         }
       ],
       "return_type": "Any"
+    }
+  },
+  "AI_ANIMAL": {
+    "0x5EFB415E": {
+      "name": "ANIMAL_SPECIES_FLOCK_AND_TUNING_CLEAR_ALL",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x1FD8BA91": {
+      "name": "ANIMAL_SPECIES_NEEDS_DOMESTICATION_LEVELS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x11DCCDAA": {
+      "name": "ANIMAL_SPECIES_SET_SPECIAL_USE_GRINGO",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x6B6191EE": {
+      "name": "ANIMAL_SPECIES_SET_UNALERTED_BEHAVIOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4DF576A7": {
+      "name": "ANIMAL_SPECIES_FLOCK_SET_ENABLED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xBF12100D": {
+      "name": "ANIMAL_SPECIES_FLOCK_SET_PARAMETER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7C795382": {
+      "name": "ANIMAL_SPECIES_FLOCK_SET_BOOLEAN_PARAMETER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x338D1CEC": {
+      "name": "ANIMAL_SPECIES_ADD_EXTERNAL_PATH_ATTRACTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xF2110753": {
+      "name": "ANIMAL_SPECIES_REMOVE_EXTERNAL_PATH_ATTRACTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x784C514C": {
+      "name": "ANIMAL_SPECIES_ADD_EXTERNAL_RANDOM_NOISE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4217D912": {
+      "name": "ANIMAL_SPECIES_ADD_EXTERNAL_REPULSION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x9D8C2744": {
+      "name": "ANIMAL_SPECIES_ADD_EXTERNAL_INFLUENCE_FLOCK_REASONER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x8020C45E": {
+      "name": "ANIMAL_SPECIES_TUNING_GET_ATTRIB_FLOAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0x651ACCB1": {
+      "name": "ANIMAL_SPECIES_TUNING_SET_ATTRIB_BOOL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x20AD711E": {
+      "name": "ANIMAL_SPECIES_TUNING_SET_ATTRIB_FLOAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x10CC05F1": {
+      "name": "ANIMAL_SPECIES_TUNING_MOVE_SET_ATTRIB",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xA6A4651B": {
+      "name": "ANIMAL_SPECIES_TUNING_SET_ATTACHMENT_WITH_OFFSET",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x168AAB9B": {
+      "name": "ANIMAL_SPECIES_TUNING_SET_ATTACHMENT_WITH_CHILDBONE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xD05DDBB6": {
+      "name": "ANIMAL_SPECIES_TUNING_SET_HUNTING_PREY_PROP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x96B26945": {
+      "name": "ANIMAL_SPECIES_TUNING_SET_ATTRIB_FLOAT_FROM_TIME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE228CC1A": {
+      "name": "ANIMAL_SPECIES_INIT_BEGIN",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xED6240F0": {
+      "name": "ANIMAL_SPECIES_INIT_REGISTER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x00760C27": {
+      "name": "ANIMAL_SPECIES_INIT_END",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0xD4DDC119": {
+      "name": "ANIMAL_SPECIES_GRINGO_CLEAR_ALL",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0xBFB65BE8": {
+      "name": "ANIMAL_SPECIES_GRINGO_LOAD_ALL",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x98073A48": {
+      "name": "ANIMAL_SPECIES_REL_CLEAR_ALL",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x1E02527F": {
+      "name": "ANIMAL_SPECIES_REL_SET_ATTACK_GRAB_ENABLED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x84B474ED": {
+      "name": "ANIMAL_SPECIES_REL_SET_PREDATOR_AND_PREY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x9D5C43C9": {
+      "name": "ANIMAL_SPECIES_REL_SET_THREAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xBF8B1BD7": {
+      "name": "ANIMAL_SPECIES_REL_SET_AVOID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x3F747178": {
+      "name": "ANIMAL_SPECIES_REL_SET_PLAY_HUNT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x586904BD": {
+      "name": "ANIMAL_SPECIES_REL_SET_PLAY_CHASE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x70C48A1C": {
+      "name": "ANIMAL_SPECIES_REL_SET_PLAY_BEG",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x70DE500E": {
+      "name": "ANIMAL_SPECIES_REL_SET_PLAY_GROWL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x6606A669": {
+      "name": "ANIMAL_SPECIES_REL_SET_PLAY_SNIFF",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x3C5700DC": {
+      "name": "ANIMAL_SPECIES_REL_GET_CAN_ATTACK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC8B4CD3F": {
+      "name": "ANIMAL_SPECIES_REL_SET_CAN_ATTACK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0482DD4E": {
+      "name": "ANIMAL_SPECIES_REL_SET_CAN_WARN",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xB5A63B67": {
+      "name": "ANIMAL_SPECIES_REL_SET_EAT_GRINGO",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xCE23118D": {
+      "name": "ANIMAL_ACTOR_GET_DOMESTICATION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x58C36502": {
+      "name": "ANIMAL_ACTOR_SET_DOMESTICATION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7D0E25DF": {
+      "name": "ANIMAL_ACTOR_GET_SPECIES",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x11150810": {
+      "name": "ANIMAL_TUNING_SET_ATTRIB_BOOL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE36EA080": {
+      "name": "ANIMAL_TUNING_SET_ATTRIB_FLOAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xABFCFF01": {
+      "name": "ANIMAL_ACTOR_SET_DOCILE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "BOOL",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xAAA8AF88": {
+      "name": "ANIMAL_ACTOR_GET_DOCILE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x57DF8CD0": {
+      "name": "ANIMAL_ACTOR_GET_GRABBED_BY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    }
+  },
+  "AI_ATTENTION": {
+    "0x945F518F": {
+      "name": "_AIATTENTIONATTRACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        },
+        {
+          "type": "float",
+          "name": "p4"
+        },
+        {
+          "type": "float",
+          "name": "p5"
+        },
+        {
+          "type": "float",
+          "name": "p6"
+        }
+      ],
+      "return_type": "int"
+    }
+  },
+  "AI_COMBAT": {
+    "0x13FA7128": {
+      "name": "COMBAT_CLASS_AI_CLEAR_ALL_ATTRIBS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE39B4D25": {
+      "name": "COMBAT_CLASS_AI_GET_ATTRIB_BOOL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xAAD75024": {
+      "name": "COMBAT_CLASS_AI_GET_ATTRIB_FLOAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x983DB127": {
+      "name": "COMBAT_CLASS_AI_GET_RANGE_ACCURACY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x69C5ADD2": {
+      "name": "COMBAT_CLASS_AI_SET_ATTRIB_BOOL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x80D51606": {
+      "name": "COMBAT_CLASS_AI_SET_ATTRIB_FLOAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x6389CF4B": {
+      "name": "COMBAT_CLASS_AI_SET_FIGHT_ATTACK_DISTANCE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE20587E7": {
+      "name": "COMBAT_CLASS_AI_SET_FIGHT_DESIRED_DISTANCE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0EF1436B": {
+      "name": "COMBAT_CLASS_AI_SET_FIGHT_TIME_BETWEEN_ATTACKS_MULTIPLIER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x1EF0E419": {
+      "name": "COMBAT_CLASS_AI_SET_FIGHT_TIME_BETWEEN_ATTACKS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xF1454677": {
+      "name": "COMBAT_CLASS_AI_SET_FRIENDLY_FIRE_CONSIDERATION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x60B705A5": {
+      "name": "COMBAT_CLASS_AI_SET_RANGE_ACCURACY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xC30DB881": {
+      "name": "COMBAT_CLASS_AI_SET_RANGE_BETWEEN_BURSTS_DELAY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x8DE6AF29": {
+      "name": "COMBAT_CLASS_NAME_REGISTER_INT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x629E2E88": {
+      "name": "COMBAT_CLASS_REQUEST_EXISTS",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x0EDD5D43": {
+      "name": "COMBAT_CLASS_REQUEST_GET_ACTOR",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x76478D6E": {
+      "name": "COMBAT_CLASS_REQUEST_GET_ENUM_INT",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xE66AD206": {
+      "name": "COMBAT_CLASS_REQUEST_COMPLETED",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0xAD3877AF": {
+      "name": "COMBAT_CLASS_SERVER_SET_SCRIPT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7F73E1E8": {
+      "name": "AI_COMBAT_SET_NEW_STATE_MACHINE_ENABLED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    }
+  },
+  "AI_CONVERSE": {
+    "0x30402375": {
+      "name": "AI_CONVERSE_SET_GREETING_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x7922F870": {
+      "name": "AI_CONVERSE_SET_GOSSIP_AMBIENT_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x663723A0": {
+      "name": "AI_CONVERSE_SET_GOSSIP_REPLY_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x93CFB180": {
+      "name": "AI_CONVERSE_SET_GOODBYE_START_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xA1FCBA24": {
+      "name": "AI_CONVERSE_SET_GOODBYE_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x7ED8B78C": {
+      "name": "AI_CONVERSE_INIT_CAMPFIRE_CONTEXT_STORAGE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xD4871BDB": {
+      "name": "AI_CONVERSE_SET_CAMPFIRE_INVITE_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xA88359B9": {
+      "name": "AI_CONVERSE_SET_CAMPFIRE_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xAD42EABC": {
+      "name": "AI_CONVERSE_SET_CAMPFIRE_STORY_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC65F6751": {
+      "name": "AI_CONVERSE_SET_CAMPFIRE_STORY_DONE_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x83CBD612": {
+      "name": "AI_CONVERSE_SET_CAMPFIRE_STORY_LEAVE_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x4AD2BC30": {
+      "name": "AI_CONVERSE_SET_CAMPFIRE_RESPONSE_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xC1F9A360": {
+      "name": "AI_SET_CAMPFIRE_STORY_ENABLED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xFCD2DE48": {
+      "name": "AI_CONVERSE_SET_GIDDYUP_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xB8F1D736": {
+      "name": "AI_CONVERSE_SET_WOAH_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xEA86A817": {
+      "name": "AI_CONVERSE_DISABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x43F59172": {
+      "name": "AI_CONVERSE_ENABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x52D984AF": {
+      "name": "AI_CONVERSE_ADD_CAMPFIRE_CONVERSER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x1D4786CF": {
+      "name": "AI_CONVERSE_REMOVE_CAMPFIRE_CONVERSER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x375BBD85": {
+      "name": "AI_CONVERSE_SET_GREET_SAUCY_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x4819FB7C": {
+      "name": "AI_CONVERSE_SET_SOLICIT_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xC4F468AA": {
+      "name": "AI_CONVERSE_SET_REJECTION_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xBD3A0E6D": {
+      "name": "GAME_ESTIMATE_MOUNT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xD6BBC8AA": {
+      "name": "AI_CONVERSE_SET_GREET_PLAYER_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    }
+  },
+  "AI_MEMORY": {
+    "0x8CD37E9E": {
+      "name": "MEMORY_CLEAR_EVENTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4485B246": {
+      "name": "MEMORY_CLEAR_ALL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xACD4084D": {
+      "name": "MEMORY_CONSIDER_ACCORDING_TO_FACTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x296C01A4": {
+      "name": "MEMORY_CONSIDER_AS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x745A1BA3": {
+      "name": "MEMORY_CONSIDER_AS_ENEMY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0810A7BA": {
+      "name": "MEMORY_GET_IS_IDENTIFIED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x45CE40FD": {
+      "name": "MEMORY_GET_IS_VISIBLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC407497F": {
+      "name": "MEMORY_GET_WAS_VISIBLE_WITHIN_TIME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xBA09085C": {
+      "name": "MEMORY_IDENTIFY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x052CC7CE": {
+      "name": "MEMORY_REPORT_POSITION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x2F589CDF": {
+      "name": "MEMORY_REPORT_POSITION_AUTO",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x05B3D34F": {
+      "name": "MEMORY_GET_MUST_IDENTIFY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5A83A1EA": {
+      "name": "MEMORY_ATTACK_ON_SIGHT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x48AA959E": {
+      "name": "MEMORY_CLEAR_RIDING_PREFERENCE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x1B72B0DD": {
+      "name": "MEMORY_PREFER_RIDING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x2F7B60A4": {
+      "name": "MEMORY_PREFER_WALKING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x2F929ECD": {
+      "name": "MEMORY_PREFER_MELEE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xC175F2B5": {
+      "name": "MEMORY_FORCE_MELEE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x937E1760": {
+      "name": "MEMORY_ALLOW_SHOOTING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE944E5F8": {
+      "name": "MEMORY_ALLOW_TAKE_COVER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xDBDB57D0": {
+      "name": "MEMORY_ALLOW_THROWING_EXPLOSIVES",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x5DD0AC4A": {
+      "name": "MEMORY_ALLOW_PICKUP_WEAPONS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x009EB4C1": {
+      "name": "MEMORY_GET_WEAPON_DRAW_PREFERENCE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xDD965D74": {
+      "name": "MEMORY_CLEAR_WEAPON_DRAW_PREFERENCE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xF8CB6260": {
+      "name": "MEMORY_SET_WEAPON_DRAW_PREFERENCE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7E77DD6C": {
+      "name": "MEMORY_GET_POSITION_LAST_KNOWN_TIME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7EDD316C": {
+      "name": "MEMORY_EVERYBODY_FORGET_ABOUT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xD1628C57": {
+      "name": "MEMORY_EVERYBODY_FORGET_ABOUT_EVERYTHING",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x052E865C": {
+      "name": "MEMORY_SHOULD_ALWAYS_PATHFIND_IN_FORMATION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xAF94B7D9": {
+      "name": "AI_GLOBAL_CLEAR_ALL_DANGER",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0xB6FCFFAA": {
+      "name": "AI_GLOBAL_CLEAR_DANGER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xFF00B4E6": {
+      "name": "AI_GLOBAL_GET_PERMANENT_DANGER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5EC098F2": {
+      "name": "AI_GLOBAL_IS_DANGER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x64C177FB": {
+      "name": "AI_GLOBAL_SET_PERMANENT_DANGER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xCF70330C": {
+      "name": "AI_GLOBAL_REPORT_DANGER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xB4621962": {
+      "name": "MEMORY_SET_UNARMED_RETREAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
     }
   },
   "AI_MISC": {
@@ -5299,9 +8670,9 @@
       "return_type": "int"
     }
   },
-  "ALLOC": {
-    "0x724B4E9B": {
-      "name": "_FONT_SCALE",
+  "AI_SPEECH2": {
+    "0xD85BAFA8": {
+      "name": "SPEECH_CONTEXT_INIT_DATA",
       "comment": "",
       "params": [
         {
@@ -5309,7 +8680,211 @@
           "name": "p0"
         }
       ],
-      "return_type": "int"
+      "return_type": "void"
+    },
+    "0xEB99D1A9": {
+      "name": "SPEECH_CONTEXT_ADD_CHILD",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0386C556": {
+      "name": "SPEECH_CONTEXT_SET_TIME_RESTRICTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xF63FA0A1": {
+      "name": "SPEECH_CONTEXT_SET_OPPOSITE_GENDER_RESTRICTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xB59AD5B1": {
+      "name": "GET_LOCKON_MISSION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4F64116B": {
+      "name": "_0x4F64116B",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xBAD8B9A8": {
+      "name": "SPEECH_CONTEXT_SET_WEATHER_RESTRICTION_GOOD",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x6CBF76AB": {
+      "name": "SPEECH_CONTEXT_SET_WEATHER_RESTRICTION_RAINY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE0DD373F": {
+      "name": "SPEECH_CONTEXT_SET_TARGET_PLAYER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x3C6FE75D": {
+      "name": "_0x3C6FE75D",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x74E7F898": {
+      "name": "SPEECH_CONTEXT_SET_PLAYER_IDENTITY_RESTRICTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xA13D379B": {
+      "name": "SPEECH_CONTEXT_SET_ALLOW_PHRASE_REUSE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xAC72E757": {
+      "name": "_0xAC72E757",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x99AFD2D1": {
+      "name": "_0x99AFD2D1",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    }
+  },
+  "AI_VISION": {
+    "0x656D3D26": {
+      "name": "CAN_ANYONE_OF_FACTION_SEE_OBJECT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "BOOL"
     }
   },
   "AI_WORLD": {
@@ -5776,6 +9351,62 @@
         }
       ],
       "return_type": "float*"
+    }
+  },
+  "ALLOC": {
+    "0x724B4E9B": {
+      "name": "_FONT_SCALE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    }
+  },
+  "AMBIENCE": {
+    "0x2A3B1045": {
+      "name": "AMBIENCE_AUDIO_ENTITY_UPDATE_TERRITORY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x27A96719": {
+      "name": "AMBIENCE_AUDIO_ENTITY_UPDATE_LOCATION",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "p0"
+        },
+        {
+          "type": "const char*",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC0556FB8": {
+      "name": "AMBIENCE_AUDIO_VALIDATE_REGION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
     }
   },
   "AMBIENT": {
@@ -6812,892 +10443,6 @@
         {
           "type": "int*",
           "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    }
-  },
-  "AI_ANIMAL": {
-    "0x5EFB415E": {
-      "name": "ANIMAL_SPECIES_FLOCK_AND_TUNING_CLEAR_ALL",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x1FD8BA91": {
-      "name": "ANIMAL_SPECIES_NEEDS_DOMESTICATION_LEVELS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x11DCCDAA": {
-      "name": "ANIMAL_SPECIES_SET_SPECIAL_USE_GRINGO",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x6B6191EE": {
-      "name": "ANIMAL_SPECIES_SET_UNALERTED_BEHAVIOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4DF576A7": {
-      "name": "ANIMAL_SPECIES_FLOCK_SET_ENABLED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xBF12100D": {
-      "name": "ANIMAL_SPECIES_FLOCK_SET_PARAMETER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x7C795382": {
-      "name": "ANIMAL_SPECIES_FLOCK_SET_BOOLEAN_PARAMETER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x338D1CEC": {
-      "name": "ANIMAL_SPECIES_ADD_EXTERNAL_PATH_ATTRACTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xF2110753": {
-      "name": "ANIMAL_SPECIES_REMOVE_EXTERNAL_PATH_ATTRACTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x784C514C": {
-      "name": "ANIMAL_SPECIES_ADD_EXTERNAL_RANDOM_NOISE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4217D912": {
-      "name": "ANIMAL_SPECIES_ADD_EXTERNAL_REPULSION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x9D8C2744": {
-      "name": "ANIMAL_SPECIES_ADD_EXTERNAL_INFLUENCE_FLOCK_REASONER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x8020C45E": {
-      "name": "ANIMAL_SPECIES_TUNING_GET_ATTRIB_FLOAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0x651ACCB1": {
-      "name": "ANIMAL_SPECIES_TUNING_SET_ATTRIB_BOOL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x20AD711E": {
-      "name": "ANIMAL_SPECIES_TUNING_SET_ATTRIB_FLOAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x10CC05F1": {
-      "name": "ANIMAL_SPECIES_TUNING_MOVE_SET_ATTRIB",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xA6A4651B": {
-      "name": "ANIMAL_SPECIES_TUNING_SET_ATTACHMENT_WITH_OFFSET",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x168AAB9B": {
-      "name": "ANIMAL_SPECIES_TUNING_SET_ATTACHMENT_WITH_CHILDBONE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xD05DDBB6": {
-      "name": "ANIMAL_SPECIES_TUNING_SET_HUNTING_PREY_PROP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x96B26945": {
-      "name": "ANIMAL_SPECIES_TUNING_SET_ATTRIB_FLOAT_FROM_TIME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE228CC1A": {
-      "name": "ANIMAL_SPECIES_INIT_BEGIN",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xED6240F0": {
-      "name": "ANIMAL_SPECIES_INIT_REGISTER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x00760C27": {
-      "name": "ANIMAL_SPECIES_INIT_END",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0xD4DDC119": {
-      "name": "ANIMAL_SPECIES_GRINGO_CLEAR_ALL",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0xBFB65BE8": {
-      "name": "ANIMAL_SPECIES_GRINGO_LOAD_ALL",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x98073A48": {
-      "name": "ANIMAL_SPECIES_REL_CLEAR_ALL",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x1E02527F": {
-      "name": "ANIMAL_SPECIES_REL_SET_ATTACK_GRAB_ENABLED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x84B474ED": {
-      "name": "ANIMAL_SPECIES_REL_SET_PREDATOR_AND_PREY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x9D5C43C9": {
-      "name": "ANIMAL_SPECIES_REL_SET_THREAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xBF8B1BD7": {
-      "name": "ANIMAL_SPECIES_REL_SET_AVOID",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x3F747178": {
-      "name": "ANIMAL_SPECIES_REL_SET_PLAY_HUNT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x586904BD": {
-      "name": "ANIMAL_SPECIES_REL_SET_PLAY_CHASE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x70C48A1C": {
-      "name": "ANIMAL_SPECIES_REL_SET_PLAY_BEG",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x70DE500E": {
-      "name": "ANIMAL_SPECIES_REL_SET_PLAY_GROWL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x6606A669": {
-      "name": "ANIMAL_SPECIES_REL_SET_PLAY_SNIFF",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x3C5700DC": {
-      "name": "ANIMAL_SPECIES_REL_GET_CAN_ATTACK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC8B4CD3F": {
-      "name": "ANIMAL_SPECIES_REL_SET_CAN_ATTACK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0482DD4E": {
-      "name": "ANIMAL_SPECIES_REL_SET_CAN_WARN",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xB5A63B67": {
-      "name": "ANIMAL_SPECIES_REL_SET_EAT_GRINGO",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xCE23118D": {
-      "name": "ANIMAL_ACTOR_GET_DOMESTICATION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x58C36502": {
-      "name": "ANIMAL_ACTOR_SET_DOMESTICATION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x7D0E25DF": {
-      "name": "ANIMAL_ACTOR_GET_SPECIES",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x11150810": {
-      "name": "ANIMAL_TUNING_SET_ATTRIB_BOOL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE36EA080": {
-      "name": "ANIMAL_TUNING_SET_ATTRIB_FLOAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xABFCFF01": {
-      "name": "ANIMAL_ACTOR_SET_DOCILE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "BOOL",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xAAA8AF88": {
-      "name": "ANIMAL_ACTOR_GET_DOCILE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x57DF8CD0": {
-      "name": "ANIMAL_ACTOR_GET_GRABBED_BY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
         }
       ],
       "return_type": "int"
@@ -13303,4676 +16048,6 @@
       "return_type": "void"
     }
   },
-  "SOCIALCLUB": {
-    "0x1EB9AF29": {
-      "name": "UI_CHALLENGE_CREATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x2A39FD8A": {
-      "name": "UI_CHALLENGE_SET_DESCRIPTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xD5ED5FCB": {
-      "name": "UI_CHALLENGE_SET_TITLE_TEXTURE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x10F5386D": {
-      "name": "UI_CHALLENGE_SET_PROGRESS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x9D9CDCE3": {
-      "name": "UI_CHALLENGE_SET_PROGRESS_DETAIL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x3731AC9F": {
-      "name": "UI_CHALLENGE_SET_TROPHY_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9CF5C747": {
-      "name": "UI_CHALLENGE_SET_OBJECTIVE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4A598723": {
-      "name": "UI_CHALLENGE_SET_OBJECTIVE_STYLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9272926C": {
-      "name": "UI_CHALLENGE_SET_OBJECTIVE_STYLE_B",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xAFC9071D": {
-      "name": "UI_CHALLENGE_SET_COLUMN_HEADER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x761A6750": {
-      "name": "UI_CHALLENGE_SET_TIME_HEADER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC201524D": {
-      "name": "UI_CHALLENGE_SET_TIME_INFO",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x04A3022E": {
-      "name": "UI_CHALLENGE_MAKE_CURRENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    }
-  },
-  "AI_COMBAT": {
-    "0x13FA7128": {
-      "name": "COMBAT_CLASS_AI_CLEAR_ALL_ATTRIBS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE39B4D25": {
-      "name": "COMBAT_CLASS_AI_GET_ATTRIB_BOOL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xAAD75024": {
-      "name": "COMBAT_CLASS_AI_GET_ATTRIB_FLOAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x983DB127": {
-      "name": "COMBAT_CLASS_AI_GET_RANGE_ACCURACY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x69C5ADD2": {
-      "name": "COMBAT_CLASS_AI_SET_ATTRIB_BOOL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x80D51606": {
-      "name": "COMBAT_CLASS_AI_SET_ATTRIB_FLOAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x6389CF4B": {
-      "name": "COMBAT_CLASS_AI_SET_FIGHT_ATTACK_DISTANCE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE20587E7": {
-      "name": "COMBAT_CLASS_AI_SET_FIGHT_DESIRED_DISTANCE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0EF1436B": {
-      "name": "COMBAT_CLASS_AI_SET_FIGHT_TIME_BETWEEN_ATTACKS_MULTIPLIER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x1EF0E419": {
-      "name": "COMBAT_CLASS_AI_SET_FIGHT_TIME_BETWEEN_ATTACKS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xF1454677": {
-      "name": "COMBAT_CLASS_AI_SET_FRIENDLY_FIRE_CONSIDERATION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x60B705A5": {
-      "name": "COMBAT_CLASS_AI_SET_RANGE_ACCURACY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xC30DB881": {
-      "name": "COMBAT_CLASS_AI_SET_RANGE_BETWEEN_BURSTS_DELAY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x8DE6AF29": {
-      "name": "COMBAT_CLASS_NAME_REGISTER_INT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x629E2E88": {
-      "name": "COMBAT_CLASS_REQUEST_EXISTS",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x0EDD5D43": {
-      "name": "COMBAT_CLASS_REQUEST_GET_ACTOR",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x76478D6E": {
-      "name": "COMBAT_CLASS_REQUEST_GET_ENUM_INT",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xE66AD206": {
-      "name": "COMBAT_CLASS_REQUEST_COMPLETED",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0xAD3877AF": {
-      "name": "COMBAT_CLASS_SERVER_SET_SCRIPT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x7F73E1E8": {
-      "name": "AI_COMBAT_SET_NEW_STATE_MACHINE_ENABLED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    }
-  },
-  "COVER": {
-    "0x50AE988A": {
-      "name": "FIND_NEAREST_COVER_LOCATION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9265B24B": {
-      "name": "_GET_COVER_LOCATIONS_IN_VOLUME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        },
-        {
-          "type": "float",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8DFF31DF": {
-      "name": "GET_COVER_LOCATION_BASE_POSITION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x620178B3": {
-      "name": "GET_COVER_LOCATION_DIRECTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0xA7F84C2F": {
-      "name": "GET_COVER_LOCATION_POSITION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x90AD2C2D": {
-      "name": "IS_COVER_LOCATION_VALID",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x6BA6BC9B": {
-      "name": "ADD_AI_COVERSET_FOR_PROPSET",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    }
-  },
-  "CURVES": {
-    "0x0C46DAB3": {
-      "name": "ENABLE_CURVE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xA5FF6076": {
-      "name": "ARE_CURVES_IN_RANGE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        },
-        {
-          "type": "float",
-          "name": "p4"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x0E018669": {
-      "name": "START_CURVE_QUERY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8C37CA1A": {
-      "name": "GET_CURVE_BY_NAME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9398BE8F": {
-      "name": "IS_CURVE_QUERY_VALID",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8E551A7C": {
-      "name": "GET_NUM_POINTS_IN_CURVE_QUERY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xBADCF1E9": {
-      "name": "GET_NUM_CURVES_IN_CURVE_QUERY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE531DCAE": {
-      "name": "GET_POINT_FROM_CURVE_QUERY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xB4D1D8A3": {
-      "name": "_0xB4D1D8A3",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xBD4E48A6": {
-      "name": "_0xBD4E48A6",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x90B514B9": {
-      "name": "_0x90B514B9",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x4F8FAF8F": {
-      "name": "REMOVE_CURVE_FROM_CURVE_QUERY_USING_CURVE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x04D89A35": {
-      "name": "_0x04D89A35",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x19D652F9": {
-      "name": "_0x19D652F9",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x39DA0B3A": {
-      "name": "_0x39DA0B3A",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x49D2C1DA": {
-      "name": "_0x49D2C1DA",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8270CE81": {
-      "name": "RELEASE_CURVE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE1007398": {
-      "name": "GET_CURVE_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9A933060": {
-      "name": "GET_CURVE_NAME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x1CDF1EC4": {
-      "name": "GET_CURVE_POINT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x74460602": {
-      "name": "SET_CURVE_ACTIVE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xA7BB9E5E": {
-      "name": "SET_CURVE_WEIGHT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xF0441E47": {
-      "name": "CURVE_NETWORK_POINT_GET_DISTANT_POINT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    }
-  },
-  "CUTSCENE": {
-    "0xD89902F1": {
-      "name": "CUTSCENE_MANAGER_DOES_CUTSCENE_EXIST",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x99D215B4": {
-      "name": "CUTSCENE_MANAGER_LOAD_CUTFILE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xA6CFA220": {
-      "name": "CUTSCENE_MANAGER_IS_CUTFILE_LOADED",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x0FE90DCB": {
-      "name": "CUTSCENE_MANAGER_GET_LOADED_CUTFILE",
-      "comment": "",
-      "params": [],
-      "return_type": "const char*"
-    },
-    "0x7716B12B": {
-      "name": "CUTSCENE_MANAGER_RESUME_LOADING",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xFD300D15": {
-      "name": "CUTSCENE_MANAGER_LOAD_CUTSCENE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xEDF1D0B4": {
-      "name": "CUTSCENE_MANAGER_IS_CUTSCENE_LOADED",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xE7F781B8": {
-      "name": "CUTSCENE_MANAGER_UNLOAD_CUTSCENE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x98A9AC9E": {
-      "name": "CUTSCENE_MANAGER_PLAY_CUTSCENE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x9E6CAD1D": {
-      "name": "CUTSCENE_MANAGER_STOP_CUTSCENE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xA61FA36B": {
-      "name": "CUTSCENE_MANAGER_IS_CUTSCENE_PLAYING",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xDE339CE1": {
-      "name": "CUTSCENE_MANAGER_IS_CUTSCENE_FINISHED",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x82F80FEA": {
-      "name": "_0x82F80FEA",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xCBE7BE6A": {
-      "name": "_0xCBE7BE6A",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9E6A776F": {
-      "name": "_0x9E6A776F",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x47FAE768": {
-      "name": "_0x47FAE768",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x93F356F4": {
-      "name": "_0x93F356F4",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xE808BFFB": {
-      "name": "CUTSCENE_MANAGER_SET_SKIP_UI_STACK_POP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE0BE8235": {
-      "name": "_0xE0BE8235",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "p0"
-        }
-      ],
-      "return_type": "const char*"
-    },
-    "0x7653788C": {
-      "name": "CUTSCENE_MANAGER_CAN_SET_POST_CUTSCENE_POSES",
-      "comment": "",
-      "params": [],
-      "return_type": "BOOL"
-    },
-    "0x98D0F458": {
-      "name": "CUTSCENE_MANAGER_CLEAR_CAN_SET_POST_CUTSCENE_POSES",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0xAC5043C5": {
-      "name": "CUTSCENE_MANAGER_GET_CURRENT_TIME",
-      "comment": "",
-      "params": [],
-      "return_type": "float"
-    },
-    "0x7263860F": {
-      "name": "CUTSCENE_MANAGER_GET_CURRENT_FRAME",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x2DB208A1": {
-      "name": "CUTSCENE_MANAGER_GET_TOTAL_FRAMES",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x1501F924": {
-      "name": "CUTSCENE_MANAGER_ENUMERATE_CUTXML_NAMES",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xC677BF51": {
-      "name": "CUTSCENE_MANAGER_GET_NUM_CUTXML_NAMES",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xC2B5BDDF": {
-      "name": "CUTSCENE_MANAGER_GET_CUTXML_NAME",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xA5691922": {
-      "name": "CUTSCENE_MANAGER_GET_NUM_CUTSCENE_ACTORS",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xC6557710": {
-      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_ACTOR_NAME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xED0BA189": {
-      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xEA8E6112": {
-      "name": "_0xEA8E6112",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xB2F2A7F2": {
-      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_ACTOR_BY_INDEX_START_ORIENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9410D992": {
-      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_ACTOR_BY_INDEX_END_ORIENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xD9E4A8DA": {
-      "name": "CUTSCENE_MANAGER_GET_NUM_CUTSCENE_PROPS",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xEBAB5F62": {
-      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_PROP_NAME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5DB05BBC": {
-      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_PROP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x3BDB2ADF": {
-      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_PROP_BY_NAME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any*",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x79C748BE": {
-      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_PROP_BY_INDEX_START_ORIENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xA56DCCF2": {
-      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_PROP_BY_INDEX_END_ORIENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x3D014AB1": {
-      "name": "CUTSCENE_MANAGER_HIDE_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xB550D120": {
-      "name": "CUTSCENE_MANAGER_SHOW_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xD79C7D6A": {
-      "name": "CUTSCENE_MANAGER_GET_INITIAL_STREAMING_LOAD_SCENE_EXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5C553565": {
-      "name": "CUTSCENE_MANAGER_GET_FINAL_STREAMING_LOAD_SCENE_EXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xB0479CB8": {
-      "name": "CUTSCENE_MANAGER_SET_FINAL_STREAMING_LOAD_SCENE_EXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x35DBDD67": {
-      "name": "CUTSCENE_MANAGER_SET_ASSET_OVERRIDE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x250232CF": {
-      "name": "CUTSCENE_MANAGER_SET_ASSET_OVERRIDE_ACTORENUM",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7007019D": {
-      "name": "CUTSCENE_MANAGER_SET_ASSET_OVERRIDE_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x24F97294": {
-      "name": "CUTSCENE_MANAGER_GET_SCRIPT_EVENT_DATA",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xDE79FA4E": {
-      "name": "CUTSCENE_MANAGER_GET_SCRIPT_EVENT_DESCRIPTION",
-      "comment": "",
-      "params": [],
-      "return_type": "const char*"
-    },
-    "0x2B45FADE": {
-      "name": "CUTSCENE_MANAGER_CLEAR_SCRIPT_EVENT",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x50A2051C": {
-      "name": "CUTSCENE_MANAGER_SET_WAS_JOHN_NOW_JACK_IN_RCM_CUTSCENE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    }
-  },
-  "FX": {
-    "0xA5A6A3E3": {
-      "name": "ENABLE_PIP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x3736FF43": {
-      "name": "IS_PIP_ENABLED",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x065B4197": {
-      "name": "IS_PIP_RENDERING",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x43939FD8": {
-      "name": "CLEAR_DECALS",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x21588246": {
-      "name": "CREATE_DECAL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xFB4CFBA0": {
-      "name": "CREATE_DIRECTION_DECAL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x7BCE4845": {
-      "name": "CREATE_DECAL_WITH_NORMAL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        },
-        {
-          "type": "Any",
-          "name": "p9"
-        },
-        {
-          "type": "Any",
-          "name": "p10"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x9E54C297": {
-      "name": "CREATE_FOOTPRINT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        },
-        {
-          "type": "float",
-          "name": "p4"
-        },
-        {
-          "type": "float",
-          "name": "p5"
-        },
-        {
-          "type": "float",
-          "name": "p6"
-        },
-        {
-          "type": "float",
-          "name": "p7"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x013A0D25": {
-      "name": "AT_FIRED_LAST",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x1182C34F": {
-      "name": "_0x1182C34F",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xD0FB6AF0": {
-      "name": "_0xD0FB6AF0",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xC00F8181": {
-      "name": "_0xC00F8181",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4897DD37": {
-      "name": "_0x4897DD37",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x6E946AF8": {
-      "name": "PPP_LOAD_PRESET",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xB6CA7EBF": {
-      "name": "PPP_UNLOAD_PRESET",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4710FD93": {
-      "name": "RESET_ANALOG_POSITIONS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x6A0A241A": {
-      "name": "PPP_GET_ELEMENT_MAGNITUDE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0xCB0BDCE9": {
-      "name": "CANCEL_DEADEYE",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0xFA43DCC5": {
-      "name": "FIRE_SHOCK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xEC906A7A": {
-      "name": "SET_SHOCK_SPEED",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC9FCD3EC": {
-      "name": "SET_SHOCK_AMPLITUDE",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xF665F9D1": {
-      "name": "DOF_PUSH",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x5EBE0C41": {
-      "name": "DOF_POP",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0xEA8964CC": {
-      "name": "DOF_SET",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x47A8DDED": {
-      "name": "DOF_SET_KERNEL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x3B32AB84": {
-      "name": "_0x3B32AB84",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xCBDD5832": {
-      "name": "REMOVE_GLOW_INDICATOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x1065D334": {
-      "name": "CREATE_OBJECT_GLOW",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xFC261530": {
-      "name": "DESTROY_OBJECT_GLOW",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x8852F896": {
-      "name": "CLEAR_TUMBLEWEEDS",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0xFDE8DFCE": {
-      "name": "ALLOW_TUMBLEWEEDS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x1EE7153B": {
-      "name": "ADD_ZOMBIE_TO_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5685A440": {
-      "name": "ADD_BLOOD_TO_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x50904C66": {
-      "name": "ADD_BLOOD_TO_CORPSE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x1A676EDF": {
-      "name": "CLEAR_CHARACTER_BLOOD",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x807C9D01": {
-      "name": "CLEAR_PLAYER_BLOOD",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x9D9E093E": {
-      "name": "SET_PLAYER_BLOOD_FADE_RATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x32F2D6F1": {
-      "name": "PRICK_PLAYER_FINGER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xA257C16D": {
-      "name": "BURN_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x3627F773": {
-      "name": "LIMIT_BLOOD_ON_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "int",
-          "name": "a2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x48123591": {
-      "name": "LOAD_PTFX_DLC_ASSETS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xA0AE0C98": {
-      "name": "ADDSHADER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    }
-  },
-  "DECORATOR": {
-    "0x9AC89564": {
-      "name": "_0x9AC89564",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xFAC315B7": {
-      "name": "_0xFAC315B7",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x1F003E6C": {
-      "name": "_0x1F003E6C",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8E101F5C": {
-      "name": "DECOR_SET_BOOL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "const char*",
-          "name": "propertyName"
-        },
-        {
-          "type": "BOOL",
-          "name": "value"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xBC7BD5CB": {
-      "name": "DECOR_SET_FLOAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xDB718B21": {
-      "name": "DECOR_SET_INT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xAAED0B69": {
-      "name": "DECOR_SET_VECTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x53D3FB4A": {
-      "name": "DECOR_SET_STRING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x44F8BCC5": {
-      "name": "DECOR_SET_OBJECT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xEDF99C77": {
-      "name": "DECOR_CHECK_STRING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "const char*",
-          "name": "propertyName"
-        },
-        {
-          "type": "const char*",
-          "name": "eventName"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x6A0FE2A0": {
-      "name": "DECOR_GET_STRING_HASH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xDBCE51E0": {
-      "name": "DECOR_GET_BOOL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8DE5382F": {
-      "name": "DECOR_GET_FLOAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xDDDE59B5": {
-      "name": "DECOR_GET_INT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x56E84C59": {
-      "name": "DECOR_GET_VECTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x24F2E859": {
-      "name": "DECOR_GET_OBJECT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xA0773F5C": {
-      "name": "DECOR_CHECK_EXIST",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "const char*",
-          "name": "propertyName"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE0E2640B": {
-      "name": "DECOR_REMOVE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "const char*",
-          "name": "propertyName"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xFDB9E349": {
-      "name": "DECOR_REMOVE_ALL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    }
-  },
-  "DLC": {
-    "0x0728B211": {
-      "name": "DLC_PRE_INIT_CONTENT",
-      "comment": "",
-      "params": [],
-      "return_type": "const char*"
-    },
-    "0xEC86DB0E": {
-      "name": "DLC_INIT_CONTENT",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x57D9950B": {
-      "name": "_DLC_FRAGMENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xF4D0807E": {
-      "name": "DLC_INIT_STRINGTABLE_STREAMABLES",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x853F71F6": {
-      "name": "DLC_IS_CONTENT_PURCHASED_FLAGS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x2F78AEFA": {
-      "name": "DLC_UNMOUNT_PACK",
-      "comment": "PS4/Switch/PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    }
-  },
-  "DOOR": {
-    "0x9CB5372B": {
-      "name": "FIND_NEAREST_DOOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x9CE0AA24": {
-      "name": "GET_DOOR_FROM_OBJECT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7F0F079B": {
-      "name": "IS_DOOR_VALID",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x19FB9518": {
-      "name": "IS_DOOR_LOCKED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x184924E2": {
-      "name": "SET_DOOR_LOCK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x48659CD7": {
-      "name": "IS_DOOR_CLOSED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x211DD9D2": {
-      "name": "IS_DOOR_OPENED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x52BB0836": {
-      "name": "IS_DOOR_OPENING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xCBA9F32C": {
-      "name": "IS_DOOR_CLOSING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xD3300956": {
-      "name": "SET_DOOR_AUTO_CLOSE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x5BCFC899": {
-      "name": "SET_DOOR_CURRENT_SPEED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x30503E81": {
-      "name": "OPEN_DOOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xAACB4435": {
-      "name": "OPEN_DOOR_DIRECTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xCF89BC95": {
-      "name": "OPEN_DOOR_FAST",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xBA51D02E": {
-      "name": "OPEN_DOOR_DIRECTION_FAST",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x075B1736": {
-      "name": "CLOSE_DOOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xFEEC0767": {
-      "name": "CLOSE_DOOR_FAST",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x3B25299D": {
-      "name": "SET_ALL_DOOR_LOCKS_VISIBLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x468DDDB3": {
-      "name": "SET_DOOR_LOCK_VISIBLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xDAD47AE6": {
-      "name": "IS_DOOR_OPEN_IN_DIRECTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "BOOL"
-    }
-  },
-  "PPPELEMENTS": {
-    "0x598815BD": {
-      "name": "_0x598815BD",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xD1C91A7F": {
-      "name": "_0xD1C91A7F",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        }
-      ],
-      "return_type": "const char*"
-    },
-    "0x7E0CDD87": {
-      "name": "_0x7E0CDD87",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xE6C1DBD9": {
-      "name": "_0xE6C1DBD9",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x00EF33EF": {
-      "name": "_0x00EF33EF",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xDF505043": {
-      "name": "_0xDF505043",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "result"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xE613AE52": {
-      "name": "_0xE613AE52",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x84F3DD81": {
-      "name": "_0x84F3DD81",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xF55B50ED": {
-      "name": "_0xF55B50ED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "result"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x6336182D": {
-      "name": "_0x6336182D",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x3A6960B2": {
-      "name": "_0x3A6960B2",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    }
-  },
-  "EVENT": {
-    "0x4911EB99": {
-      "name": "IS_EVENT_VALID",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x184BD1BC": {
-      "name": "GET_EVENT_FROM_OBJECT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Object",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Object"
-    },
-    "0xB64DDA6F": {
-      "name": "GET_OBJECT_FROM_EVENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "int*",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int*"
-    },
-    "0xF7DA8F09": {
-      "name": "COPY_EVENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xD938B523": {
-      "name": "GET_EVENT_LAYOUT",
-      "comment": "",
-      "params": [],
-      "return_type": "Layout"
-    },
-    "0x6D660453": {
-      "name": "GET_EVENT_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE2ED95CC": {
-      "name": "GET_EVENT_TARGET_AS_OBJECT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xBDD4D4D5": {
-      "name": "GET_EVENT_TARGET_AS_PHYSINST",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x0B5431C9": {
-      "name": "GET_EVENT_PERPETRATOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x17CF885F": {
-      "name": "_ADD_EVENT_RESPONSE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8DF144C2": {
-      "name": "_ADD_RANGED_EVENT_RESPONSE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xFEE731AF": {
-      "name": "REMOVE_EVENT_RESPONSE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x85D62384": {
-      "name": "RANGED_EVENT_RESPONSE_INIT_COMPLETE",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0xFB227D11": {
-      "name": "REGISTER_FOR_CREATION_EVENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x82112B85": {
-      "name": "GET_EVENT_TIME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xBC58F1EA": {
-      "name": "_GET_ITERATION_SET",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "setId"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x24C18749": {
-      "name": "CREATE_EVENT_TRAP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x88943B5B": {
-      "name": "EVENT_TRAP_ON_VOLUME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x3D2786E5": {
-      "name": "EVENT_TRAP_ON_SPHERE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        },
-        {
-          "type": "float",
-          "name": "p4"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x6B5DF46D": {
-      "name": "EVENT_TRAP_ON_PERPETRATOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0AA5D947": {
-      "name": "EVENT_TRAP_ON_TARGET",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x1105FB64": {
-      "name": "EVENT_TRAP_ON_OWNER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x08765C6B": {
-      "name": "EVENT_TRAP_STORE_EVENTS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xDE9AA6E5": {
-      "name": "EVENT_TRAP_CLEAR_EVENTS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x54F8EAA4": {
-      "name": "EVENT_TRAP_SUCCESSFUL_TRAP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xAA24E0CC": {
-      "name": "EVENT_TRAP_CLEAR_TRAP_FLAG",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x19F62133": {
-      "name": "GET_NUM_EVENT_RESPONSES",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xB573FF63": {
-      "name": "GET_EVENT_RESPONSE_ID",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x586714AE": {
-      "name": "GET_EVENT_FOR_RESPONSE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    }
-  },
-  "EXPLOSION": {
-    "0xE7023D23": {
-      "name": "_CREATE_EXPLOSION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Vector3*",
-          "name": "position"
-        },
-        {
-          "type": "const char*",
-          "name": "explosionName"
-        },
-        {
-          "type": "BOOL",
-          "name": "p2"
-        },
-        {
-          "type": "Vector3*",
-          "name": "damage"
-        },
-        {
-          "type": "BOOL",
-          "name": "p4"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x651F6299": {
-      "name": "ENABLE_REPLICATION_SET_EXPLOSION",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "p0"
-        }
-      ],
-      "return_type": "const char*"
-    }
-  },
-  "FACTION": {
-    "0x40ABFD17": {
-      "name": "RELOAD_FACTIONS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x28413943": {
-      "name": "RESET_FACTIONS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x52E2A611": {
-      "name": "GET_ACTOR_FACTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xCC63951A": {
-      "name": "SET_ACTOR_FACTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x5E2F718D": {
-      "name": "IS_FACTION_VALID",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x22424394": {
-      "name": "VERIFY_FACTION_ENUM",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0xDCB960C5": {
-      "name": "SET_FACTION_IS_LAWFUL_TO_ATTACK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xB58013D7": {
-      "name": "GET_FACTION_IS_LAWFUL_TO_ATTACK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xD771AF0B": {
-      "name": "SET_FACTIONS_STATUS_ONE_WAY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4C28B11E": {
-      "name": "SET_FACTIONS_STATUS_TWO_WAY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x6118212B": {
-      "name": "SET_AMBIENT_FACTIONS_STATUS_TWO_WAY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x902781BF": {
-      "name": "RESET_FACTIONS_STATUS_TWO_WAY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xF9C5DC76": {
-      "name": "RESET_AMBIENT_FACTIONS_STATUS_TWO_WAY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x8E56236D": {
-      "name": "GET_FACTIONS_STATUS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x463F75F8": {
-      "name": "SET_FACTION_TO_FACTION_ACCURACY_SCALE_FACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xA9A18E5A": {
-      "name": "SET_FACTION_TO_FACTION_DAMAGE_SCALE_FACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xEF639583": {
-      "name": "CLEAR_FACTION_STATUS_TO_INDIVIDUAL_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x784398CB": {
-      "name": "GET_FACTION_STATUS_TO_INDIVIDUAL_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xBC44D31D": {
-      "name": "SET_FACTION_STATUS_TO_INDIVIDUAL_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    }
-  },
-  "AI_VISION": {
-    "0x656D3D26": {
-      "name": "CAN_ANYONE_OF_FACTION_SEE_OBJECT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "BOOL"
-    }
-  },
-  "WORLD": {
-    "0x9A93E7CA": {
-      "name": "CLEAR_AREA_OF_TREE_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x59A7835E": {
-      "name": "RESET_TREE_TYPE_CLEARING",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x25690082": {
-      "name": "RESET_THIS_TREE_TYPE_CLEARING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE92C3435": {
-      "name": "SET_DUST_LEVEL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xDB86F53B": {
-      "name": "SET_DUST_LEVEL_MODIFIER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8BA565F7": {
-      "name": "SET_DUST_LEVEL_MID",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xB8E09389": {
-      "name": "SET_DUST_LEVEL_FAR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9AA8A1B1": {
-      "name": "CLEAR_AREA_OF_GRASS",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x002B0698": {
-      "name": "CLEAR_AREA_OF_BREAKABLE_TREES",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x57478561": {
-      "name": "RESET_THIS_BREAKABLE_TREE_CLEARING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x39B0CFE5": {
-      "name": "RESET_ALL_BREAKABLE_TREE_CLEARINGS",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xDCAE6935": {
-      "name": "RELOAD_SMICTIONARY_LIST",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x28246500": {
-      "name": "SET_ZOMBIE_DLC_IS_ACTIVE",
-      "comment": "PS4/Switch/PC only",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x8CF15FCB": {
-      "name": "ZOMBIE_DLC_IS_ACTIVE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x4A8066FB": {
-      "name": "ZOMBIE_DLC_LOAD_ASSETS",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x1DDB57A6": {
-      "name": "ZOMBIE_DLC_LOAD_ASSETS_MP",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x88863344": {
-      "name": "ZOMBIE_DLC_UNLOAD_ASSETS",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xE7371670": {
-      "name": "ZOMBIE_DLC_IS_LOAD_COMPLETE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x03E2B631": {
-      "name": "ZOMBIE_DLC_IS_UNLOAD_COMPLETE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xCA840DBB": {
-      "name": "_SET_ZOMBIE_DLC_PHOSPHORUS_AMMO_ACTIVE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x4F3F3CA5": {
-      "name": "_IS_ZOMBIE_DLC_PHOSPHORUS_AMMO_ACTIVE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xC587FA2B": {
-      "name": "CREATE_FIRE_ON_OBJECT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xD4799325": {
-      "name": "CREATE_FIRE_IN_VOLUME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        },
-        {
-          "type": "Any",
-          "name": "p9"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x9544570A": {
-      "name": "STOP_ALL_FIRES",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x8011737F": {
-      "name": "_0x8011737F",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x5402321A": {
-      "name": "CREATE_FIRE_PROPERTY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any*",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x2AC74780": {
-      "name": "GET_FIRE_PROPERTY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any*"
-    },
-    "0x466C02BA": {
-      "name": "STOP_ALL_FIRE_IN_SPHERE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xEC3A9EBB": {
-      "name": "STOP_ALL_FIRE_IN_VOLUME",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0xADB3E8D9": {
-      "name": "REPLACE_WORLD_SECTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x08D06543": {
-      "name": "REPLACE_WORLD_SECTOR_LOAD_BOUNDING_BOX",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xAD5613FD": {
-      "name": "ENABLE_WORLD_SECTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xB511D087": {
-      "name": "DISABLE_WORLD_SECTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x7ECE15BE": {
-      "name": "ENABLE_CHILD_SECTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x9E1AE585": {
-      "name": "DISABLE_CHILD_SECTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4E6A78B5": {
-      "name": "HIDE_CHILD_SECTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x63A83655": {
-      "name": "SHOW_CHILD_SECTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE437932A": {
-      "name": "SET_USE_ACTOR_STAGGER",
-      "comment": "PS4/Switch/PC only",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xBBAE9CBD": {
-      "name": "FIRE_CREATE_HANDLE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xA488E930": {
-      "name": "FIRE_IS_HANDLE_VALID",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xB14B936A": {
-      "name": "FIRE_RELEASE_HANDLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xD2BB733E": {
-      "name": "_RELEASE_INFINITE_FIRE_DESCRIPTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        },
-        {
-          "type": "Any",
-          "name": "p9"
-        },
-        {
-          "type": "Any",
-          "name": "p10"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x91396EB7": {
-      "name": "_0x91396EB7",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9679CF84": {
-      "name": "FIRE_CREATE_ON_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xB65ADFAC": {
-      "name": "FIRE_CREATE_IN_VOLUME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x30C4CA99": {
-      "name": "FIRE_IS_ACTOR_ON_FIRE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x15001332": {
-      "name": "FIRE_STOP_ALL_FIRES",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xF635B9EA": {
-      "name": "FIRE_STOP_ON_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x11A65FFB": {
-      "name": "FIRE_STOP_FLAMES_IN_VOLUME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x15683736": {
-      "name": "FIRE_GET_OWNER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE5C7E4C9": {
-      "name": "FIRE_SET_OWNER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x3D5D3B26": {
-      "name": "FIRE_SET_DAMAGE_ALLOWED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x03240324": {
-      "name": "FIRE_SET_CONTROL_VOLUME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE5E04E83": {
-      "name": "FIRE_SET_MAX_FLAMES",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x9C471E7D": {
-      "name": "FIRE_SET_TARGET_FILL_PERCENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x1A82B949": {
-      "name": "FIRE_SET_GROW_RATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x7906A950": {
-      "name": "FIRE_SET_DECAY_RATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x6471D75C": {
-      "name": "FIRE_SET_EXPIRE_ALLOWED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x53895856": {
-      "name": "FIRE_SET_GROW_ALLOWED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xDEE6523D": {
-      "name": "COUNT_FLAMES_IN_SPHERE",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x3DD3E1EB": {
-      "name": "COUNT_FLAMES_IN_VOLUME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x28DAED2A": {
-      "name": "FIRE_ARE_ANY_FLAMES_IN_VOLUME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x3F67DEDB": {
-      "name": "FIRE_SET_GUNS_BLAZING_ACTIVE",
-      "comment": "",
-      "params": [
-        {
-          "type": "BOOL",
-          "name": "toggle"
-        }
-      ],
-      "return_type": "int"
-    }
-  },
   "CORE": {
     "0x14993D3B": {
       "name": "_0x14993D3B",
@@ -20183,6 +18258,3834 @@
       "return_type": "int"
     }
   },
+  "COVER": {
+    "0x50AE988A": {
+      "name": "FIND_NEAREST_COVER_LOCATION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x9265B24B": {
+      "name": "_GET_COVER_LOCATIONS_IN_VOLUME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        },
+        {
+          "type": "float",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8DFF31DF": {
+      "name": "GET_COVER_LOCATION_BASE_POSITION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x620178B3": {
+      "name": "GET_COVER_LOCATION_DIRECTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0xA7F84C2F": {
+      "name": "GET_COVER_LOCATION_POSITION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x90AD2C2D": {
+      "name": "IS_COVER_LOCATION_VALID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x6BA6BC9B": {
+      "name": "ADD_AI_COVERSET_FOR_PROPSET",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    }
+  },
+  "CURVES": {
+    "0x0C46DAB3": {
+      "name": "ENABLE_CURVE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xA5FF6076": {
+      "name": "ARE_CURVES_IN_RANGE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        },
+        {
+          "type": "float",
+          "name": "p4"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x0E018669": {
+      "name": "START_CURVE_QUERY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8C37CA1A": {
+      "name": "GET_CURVE_BY_NAME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x9398BE8F": {
+      "name": "IS_CURVE_QUERY_VALID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8E551A7C": {
+      "name": "GET_NUM_POINTS_IN_CURVE_QUERY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xBADCF1E9": {
+      "name": "GET_NUM_CURVES_IN_CURVE_QUERY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE531DCAE": {
+      "name": "GET_POINT_FROM_CURVE_QUERY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xB4D1D8A3": {
+      "name": "_0xB4D1D8A3",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xBD4E48A6": {
+      "name": "_0xBD4E48A6",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x90B514B9": {
+      "name": "_0x90B514B9",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x4F8FAF8F": {
+      "name": "REMOVE_CURVE_FROM_CURVE_QUERY_USING_CURVE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x04D89A35": {
+      "name": "_0x04D89A35",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x19D652F9": {
+      "name": "_0x19D652F9",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x39DA0B3A": {
+      "name": "_0x39DA0B3A",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x49D2C1DA": {
+      "name": "_0x49D2C1DA",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8270CE81": {
+      "name": "RELEASE_CURVE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE1007398": {
+      "name": "GET_CURVE_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x9A933060": {
+      "name": "GET_CURVE_NAME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x1CDF1EC4": {
+      "name": "GET_CURVE_POINT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x74460602": {
+      "name": "SET_CURVE_ACTIVE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xA7BB9E5E": {
+      "name": "SET_CURVE_WEIGHT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xF0441E47": {
+      "name": "CURVE_NETWORK_POINT_GET_DISTANT_POINT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    }
+  },
+  "CUTSCENE": {
+    "0xD89902F1": {
+      "name": "CUTSCENE_MANAGER_DOES_CUTSCENE_EXIST",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x99D215B4": {
+      "name": "CUTSCENE_MANAGER_LOAD_CUTFILE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xA6CFA220": {
+      "name": "CUTSCENE_MANAGER_IS_CUTFILE_LOADED",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x0FE90DCB": {
+      "name": "CUTSCENE_MANAGER_GET_LOADED_CUTFILE",
+      "comment": "",
+      "params": [],
+      "return_type": "const char*"
+    },
+    "0x7716B12B": {
+      "name": "CUTSCENE_MANAGER_RESUME_LOADING",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xFD300D15": {
+      "name": "CUTSCENE_MANAGER_LOAD_CUTSCENE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xEDF1D0B4": {
+      "name": "CUTSCENE_MANAGER_IS_CUTSCENE_LOADED",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xE7F781B8": {
+      "name": "CUTSCENE_MANAGER_UNLOAD_CUTSCENE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x98A9AC9E": {
+      "name": "CUTSCENE_MANAGER_PLAY_CUTSCENE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x9E6CAD1D": {
+      "name": "CUTSCENE_MANAGER_STOP_CUTSCENE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xA61FA36B": {
+      "name": "CUTSCENE_MANAGER_IS_CUTSCENE_PLAYING",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xDE339CE1": {
+      "name": "CUTSCENE_MANAGER_IS_CUTSCENE_FINISHED",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x82F80FEA": {
+      "name": "_0x82F80FEA",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xCBE7BE6A": {
+      "name": "_0xCBE7BE6A",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x9E6A776F": {
+      "name": "_0x9E6A776F",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x47FAE768": {
+      "name": "_0x47FAE768",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x93F356F4": {
+      "name": "_0x93F356F4",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xE808BFFB": {
+      "name": "CUTSCENE_MANAGER_SET_SKIP_UI_STACK_POP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE0BE8235": {
+      "name": "_0xE0BE8235",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "p0"
+        }
+      ],
+      "return_type": "const char*"
+    },
+    "0x7653788C": {
+      "name": "CUTSCENE_MANAGER_CAN_SET_POST_CUTSCENE_POSES",
+      "comment": "",
+      "params": [],
+      "return_type": "BOOL"
+    },
+    "0x98D0F458": {
+      "name": "CUTSCENE_MANAGER_CLEAR_CAN_SET_POST_CUTSCENE_POSES",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0xAC5043C5": {
+      "name": "CUTSCENE_MANAGER_GET_CURRENT_TIME",
+      "comment": "",
+      "params": [],
+      "return_type": "float"
+    },
+    "0x7263860F": {
+      "name": "CUTSCENE_MANAGER_GET_CURRENT_FRAME",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x2DB208A1": {
+      "name": "CUTSCENE_MANAGER_GET_TOTAL_FRAMES",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x1501F924": {
+      "name": "CUTSCENE_MANAGER_ENUMERATE_CUTXML_NAMES",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xC677BF51": {
+      "name": "CUTSCENE_MANAGER_GET_NUM_CUTXML_NAMES",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xC2B5BDDF": {
+      "name": "CUTSCENE_MANAGER_GET_CUTXML_NAME",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xA5691922": {
+      "name": "CUTSCENE_MANAGER_GET_NUM_CUTSCENE_ACTORS",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xC6557710": {
+      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_ACTOR_NAME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xED0BA189": {
+      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xEA8E6112": {
+      "name": "_0xEA8E6112",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xB2F2A7F2": {
+      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_ACTOR_BY_INDEX_START_ORIENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x9410D992": {
+      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_ACTOR_BY_INDEX_END_ORIENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xD9E4A8DA": {
+      "name": "CUTSCENE_MANAGER_GET_NUM_CUTSCENE_PROPS",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xEBAB5F62": {
+      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_PROP_NAME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5DB05BBC": {
+      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_PROP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x3BDB2ADF": {
+      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_PROP_BY_NAME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any*",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x79C748BE": {
+      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_PROP_BY_INDEX_START_ORIENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xA56DCCF2": {
+      "name": "CUTSCENE_MANAGER_GET_CUTSCENE_PROP_BY_INDEX_END_ORIENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x3D014AB1": {
+      "name": "CUTSCENE_MANAGER_HIDE_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xB550D120": {
+      "name": "CUTSCENE_MANAGER_SHOW_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xD79C7D6A": {
+      "name": "CUTSCENE_MANAGER_GET_INITIAL_STREAMING_LOAD_SCENE_EXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5C553565": {
+      "name": "CUTSCENE_MANAGER_GET_FINAL_STREAMING_LOAD_SCENE_EXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xB0479CB8": {
+      "name": "CUTSCENE_MANAGER_SET_FINAL_STREAMING_LOAD_SCENE_EXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x35DBDD67": {
+      "name": "CUTSCENE_MANAGER_SET_ASSET_OVERRIDE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x250232CF": {
+      "name": "CUTSCENE_MANAGER_SET_ASSET_OVERRIDE_ACTORENUM",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7007019D": {
+      "name": "CUTSCENE_MANAGER_SET_ASSET_OVERRIDE_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x24F97294": {
+      "name": "CUTSCENE_MANAGER_GET_SCRIPT_EVENT_DATA",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xDE79FA4E": {
+      "name": "CUTSCENE_MANAGER_GET_SCRIPT_EVENT_DESCRIPTION",
+      "comment": "",
+      "params": [],
+      "return_type": "const char*"
+    },
+    "0x2B45FADE": {
+      "name": "CUTSCENE_MANAGER_CLEAR_SCRIPT_EVENT",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x50A2051C": {
+      "name": "CUTSCENE_MANAGER_SET_WAS_JOHN_NOW_JACK_IN_RCM_CUTSCENE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    }
+  },
+  "DECORATOR": {
+    "0x9AC89564": {
+      "name": "_0x9AC89564",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xFAC315B7": {
+      "name": "_0xFAC315B7",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x1F003E6C": {
+      "name": "_0x1F003E6C",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8E101F5C": {
+      "name": "DECOR_SET_BOOL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "const char*",
+          "name": "propertyName"
+        },
+        {
+          "type": "BOOL",
+          "name": "value"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xBC7BD5CB": {
+      "name": "DECOR_SET_FLOAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xDB718B21": {
+      "name": "DECOR_SET_INT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xAAED0B69": {
+      "name": "DECOR_SET_VECTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x53D3FB4A": {
+      "name": "DECOR_SET_STRING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x44F8BCC5": {
+      "name": "DECOR_SET_OBJECT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xEDF99C77": {
+      "name": "DECOR_CHECK_STRING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "const char*",
+          "name": "propertyName"
+        },
+        {
+          "type": "const char*",
+          "name": "eventName"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x6A0FE2A0": {
+      "name": "DECOR_GET_STRING_HASH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xDBCE51E0": {
+      "name": "DECOR_GET_BOOL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8DE5382F": {
+      "name": "DECOR_GET_FLOAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xDDDE59B5": {
+      "name": "DECOR_GET_INT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x56E84C59": {
+      "name": "DECOR_GET_VECTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x24F2E859": {
+      "name": "DECOR_GET_OBJECT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xA0773F5C": {
+      "name": "DECOR_CHECK_EXIST",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "const char*",
+          "name": "propertyName"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE0E2640B": {
+      "name": "DECOR_REMOVE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "const char*",
+          "name": "propertyName"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xFDB9E349": {
+      "name": "DECOR_REMOVE_ALL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    }
+  },
+  "DLC": {
+    "0x0728B211": {
+      "name": "DLC_PRE_INIT_CONTENT",
+      "comment": "",
+      "params": [],
+      "return_type": "const char*"
+    },
+    "0xEC86DB0E": {
+      "name": "DLC_INIT_CONTENT",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x57D9950B": {
+      "name": "_DLC_FRAGMENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xF4D0807E": {
+      "name": "DLC_INIT_STRINGTABLE_STREAMABLES",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x853F71F6": {
+      "name": "DLC_IS_CONTENT_PURCHASED_FLAGS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x2F78AEFA": {
+      "name": "DLC_UNMOUNT_PACK",
+      "comment": "PS4/Switch/PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    }
+  },
+  "DOOR": {
+    "0x9CB5372B": {
+      "name": "FIND_NEAREST_DOOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x9CE0AA24": {
+      "name": "GET_DOOR_FROM_OBJECT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7F0F079B": {
+      "name": "IS_DOOR_VALID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x19FB9518": {
+      "name": "IS_DOOR_LOCKED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x184924E2": {
+      "name": "SET_DOOR_LOCK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x48659CD7": {
+      "name": "IS_DOOR_CLOSED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x211DD9D2": {
+      "name": "IS_DOOR_OPENED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x52BB0836": {
+      "name": "IS_DOOR_OPENING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xCBA9F32C": {
+      "name": "IS_DOOR_CLOSING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xD3300956": {
+      "name": "SET_DOOR_AUTO_CLOSE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x5BCFC899": {
+      "name": "SET_DOOR_CURRENT_SPEED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x30503E81": {
+      "name": "OPEN_DOOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xAACB4435": {
+      "name": "OPEN_DOOR_DIRECTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xCF89BC95": {
+      "name": "OPEN_DOOR_FAST",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xBA51D02E": {
+      "name": "OPEN_DOOR_DIRECTION_FAST",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x075B1736": {
+      "name": "CLOSE_DOOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xFEEC0767": {
+      "name": "CLOSE_DOOR_FAST",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x3B25299D": {
+      "name": "SET_ALL_DOOR_LOCKS_VISIBLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x468DDDB3": {
+      "name": "SET_DOOR_LOCK_VISIBLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xDAD47AE6": {
+      "name": "IS_DOOR_OPEN_IN_DIRECTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "BOOL"
+    }
+  },
+  "ENTITY": {
+    "0xE6644CE5": {
+      "name": "SET_DRAW_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x085A9CA6": {
+      "name": "GET_DRAW_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    }
+  },
+  "EVENT": {
+    "0x4911EB99": {
+      "name": "IS_EVENT_VALID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x184BD1BC": {
+      "name": "GET_EVENT_FROM_OBJECT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Object",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Object"
+    },
+    "0xB64DDA6F": {
+      "name": "GET_OBJECT_FROM_EVENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "int*",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int*"
+    },
+    "0xF7DA8F09": {
+      "name": "COPY_EVENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xD938B523": {
+      "name": "GET_EVENT_LAYOUT",
+      "comment": "",
+      "params": [],
+      "return_type": "Layout"
+    },
+    "0x6D660453": {
+      "name": "GET_EVENT_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE2ED95CC": {
+      "name": "GET_EVENT_TARGET_AS_OBJECT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xBDD4D4D5": {
+      "name": "GET_EVENT_TARGET_AS_PHYSINST",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x0B5431C9": {
+      "name": "GET_EVENT_PERPETRATOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x17CF885F": {
+      "name": "_ADD_EVENT_RESPONSE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8DF144C2": {
+      "name": "_ADD_RANGED_EVENT_RESPONSE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xFEE731AF": {
+      "name": "REMOVE_EVENT_RESPONSE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x85D62384": {
+      "name": "RANGED_EVENT_RESPONSE_INIT_COMPLETE",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0xFB227D11": {
+      "name": "REGISTER_FOR_CREATION_EVENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x82112B85": {
+      "name": "GET_EVENT_TIME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xBC58F1EA": {
+      "name": "_GET_ITERATION_SET",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "setId"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x24C18749": {
+      "name": "CREATE_EVENT_TRAP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x88943B5B": {
+      "name": "EVENT_TRAP_ON_VOLUME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x3D2786E5": {
+      "name": "EVENT_TRAP_ON_SPHERE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        },
+        {
+          "type": "float",
+          "name": "p4"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x6B5DF46D": {
+      "name": "EVENT_TRAP_ON_PERPETRATOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0AA5D947": {
+      "name": "EVENT_TRAP_ON_TARGET",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x1105FB64": {
+      "name": "EVENT_TRAP_ON_OWNER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x08765C6B": {
+      "name": "EVENT_TRAP_STORE_EVENTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xDE9AA6E5": {
+      "name": "EVENT_TRAP_CLEAR_EVENTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x54F8EAA4": {
+      "name": "EVENT_TRAP_SUCCESSFUL_TRAP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xAA24E0CC": {
+      "name": "EVENT_TRAP_CLEAR_TRAP_FLAG",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x19F62133": {
+      "name": "GET_NUM_EVENT_RESPONSES",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xB573FF63": {
+      "name": "GET_EVENT_RESPONSE_ID",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x586714AE": {
+      "name": "GET_EVENT_FOR_RESPONSE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    }
+  },
+  "EXPLOSION": {
+    "0xE7023D23": {
+      "name": "_CREATE_EXPLOSION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Vector3*",
+          "name": "position"
+        },
+        {
+          "type": "const char*",
+          "name": "explosionName"
+        },
+        {
+          "type": "BOOL",
+          "name": "p2"
+        },
+        {
+          "type": "Vector3*",
+          "name": "damage"
+        },
+        {
+          "type": "BOOL",
+          "name": "p4"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x651F6299": {
+      "name": "ENABLE_REPLICATION_SET_EXPLOSION",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "p0"
+        }
+      ],
+      "return_type": "const char*"
+    }
+  },
+  "FACTION": {
+    "0x40ABFD17": {
+      "name": "RELOAD_FACTIONS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x28413943": {
+      "name": "RESET_FACTIONS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x52E2A611": {
+      "name": "GET_ACTOR_FACTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xCC63951A": {
+      "name": "SET_ACTOR_FACTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x5E2F718D": {
+      "name": "IS_FACTION_VALID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x22424394": {
+      "name": "VERIFY_FACTION_ENUM",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0xDCB960C5": {
+      "name": "SET_FACTION_IS_LAWFUL_TO_ATTACK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xB58013D7": {
+      "name": "GET_FACTION_IS_LAWFUL_TO_ATTACK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xD771AF0B": {
+      "name": "SET_FACTIONS_STATUS_ONE_WAY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4C28B11E": {
+      "name": "SET_FACTIONS_STATUS_TWO_WAY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x6118212B": {
+      "name": "SET_AMBIENT_FACTIONS_STATUS_TWO_WAY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x902781BF": {
+      "name": "RESET_FACTIONS_STATUS_TWO_WAY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xF9C5DC76": {
+      "name": "RESET_AMBIENT_FACTIONS_STATUS_TWO_WAY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x8E56236D": {
+      "name": "GET_FACTIONS_STATUS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x463F75F8": {
+      "name": "SET_FACTION_TO_FACTION_ACCURACY_SCALE_FACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xA9A18E5A": {
+      "name": "SET_FACTION_TO_FACTION_DAMAGE_SCALE_FACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xEF639583": {
+      "name": "CLEAR_FACTION_STATUS_TO_INDIVIDUAL_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x784398CB": {
+      "name": "GET_FACTION_STATUS_TO_INDIVIDUAL_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xBC44D31D": {
+      "name": "SET_FACTION_STATUS_TO_INDIVIDUAL_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    }
+  },
+  "FX": {
+    "0xA5A6A3E3": {
+      "name": "ENABLE_PIP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x3736FF43": {
+      "name": "IS_PIP_ENABLED",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x065B4197": {
+      "name": "IS_PIP_RENDERING",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x43939FD8": {
+      "name": "CLEAR_DECALS",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x21588246": {
+      "name": "CREATE_DECAL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xFB4CFBA0": {
+      "name": "CREATE_DIRECTION_DECAL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7BCE4845": {
+      "name": "CREATE_DECAL_WITH_NORMAL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        },
+        {
+          "type": "Any",
+          "name": "p9"
+        },
+        {
+          "type": "Any",
+          "name": "p10"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x9E54C297": {
+      "name": "CREATE_FOOTPRINT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        },
+        {
+          "type": "float",
+          "name": "p4"
+        },
+        {
+          "type": "float",
+          "name": "p5"
+        },
+        {
+          "type": "float",
+          "name": "p6"
+        },
+        {
+          "type": "float",
+          "name": "p7"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x013A0D25": {
+      "name": "AT_FIRED_LAST",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x1182C34F": {
+      "name": "_0x1182C34F",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xD0FB6AF0": {
+      "name": "_0xD0FB6AF0",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xC00F8181": {
+      "name": "_0xC00F8181",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4897DD37": {
+      "name": "_0x4897DD37",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x6E946AF8": {
+      "name": "PPP_LOAD_PRESET",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xB6CA7EBF": {
+      "name": "PPP_UNLOAD_PRESET",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4710FD93": {
+      "name": "RESET_ANALOG_POSITIONS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x6A0A241A": {
+      "name": "PPP_GET_ELEMENT_MAGNITUDE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0xCB0BDCE9": {
+      "name": "CANCEL_DEADEYE",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0xFA43DCC5": {
+      "name": "FIRE_SHOCK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xEC906A7A": {
+      "name": "SET_SHOCK_SPEED",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC9FCD3EC": {
+      "name": "SET_SHOCK_AMPLITUDE",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xF665F9D1": {
+      "name": "DOF_PUSH",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x5EBE0C41": {
+      "name": "DOF_POP",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0xEA8964CC": {
+      "name": "DOF_SET",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x47A8DDED": {
+      "name": "DOF_SET_KERNEL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x3B32AB84": {
+      "name": "_0x3B32AB84",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xCBDD5832": {
+      "name": "REMOVE_GLOW_INDICATOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x1065D334": {
+      "name": "CREATE_OBJECT_GLOW",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xFC261530": {
+      "name": "DESTROY_OBJECT_GLOW",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x8852F896": {
+      "name": "CLEAR_TUMBLEWEEDS",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0xFDE8DFCE": {
+      "name": "ALLOW_TUMBLEWEEDS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x1EE7153B": {
+      "name": "ADD_ZOMBIE_TO_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5685A440": {
+      "name": "ADD_BLOOD_TO_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x50904C66": {
+      "name": "ADD_BLOOD_TO_CORPSE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x1A676EDF": {
+      "name": "CLEAR_CHARACTER_BLOOD",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x807C9D01": {
+      "name": "CLEAR_PLAYER_BLOOD",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x9D9E093E": {
+      "name": "SET_PLAYER_BLOOD_FADE_RATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x32F2D6F1": {
+      "name": "PRICK_PLAYER_FINGER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xA257C16D": {
+      "name": "BURN_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x3627F773": {
+      "name": "LIMIT_BLOOD_ON_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "int",
+          "name": "a2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x48123591": {
+      "name": "LOAD_PTFX_DLC_ASSETS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xA0AE0C98": {
+      "name": "ADDSHADER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    }
+  },
+  "GAME": {
+    "0x6FCF6BC8": {
+      "name": "DISABLE_PLAYER_GRINGO_USE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x5A9D0738": {
+      "name": "IS_MISSION_SCRIPT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x15040CD2": {
+      "name": "SET_IS_MISSION_SCRIPT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x45589499": {
+      "name": "_0x45589499",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xDD9BD22B": {
+      "name": "GET_GAME_STATE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x9B71351C": {
+      "name": "SET_PAUSE_SCRIPT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xFEA58D57": {
+      "name": "ENABLE_USE_CONTEXTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x2ADA3DD4": {
+      "name": "ARE_USE_CONTEXTS_ENABLED",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x115CD0CC": {
+      "name": "IS_SCRIPT_USE_CONTEXT_VALID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x039E7F1D": {
+      "name": "ADD_SCRIPT_USE_CONTEXT_IN_VOLUME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        },
+        {
+          "type": "Any",
+          "name": "p9"
+        },
+        {
+          "type": "Any",
+          "name": "p10"
+        },
+        {
+          "type": "Any",
+          "name": "p11"
+        },
+        {
+          "type": "Any",
+          "name": "p12"
+        },
+        {
+          "type": "Any",
+          "name": "p13"
+        },
+        {
+          "type": "Any",
+          "name": "p14"
+        },
+        {
+          "type": "Any",
+          "name": "p15"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xD7591B0E": {
+      "name": "ADD_SCRIPT_USE_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "gxtName"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "int",
+          "name": "button"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "int",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xF48F8F09": {
+      "name": "_0xF48F8F09",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x45C1C061": {
+      "name": "IS_SCRIPT_USE_CONTEXT_PRESSED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x971559CA": {
+      "name": "WAS_SCRIPT_USE_CONTEXT_EVER_PRESSED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x3ECD8FEE": {
+      "name": "SET_USE_CONTEXT_TEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x4F52CB58": {
+      "name": "RELEASE_SCRIPT_USE_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xA3E1EF71": {
+      "name": "NET_MAILBOX_IS_SIGNED_INTO_SC",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x6B439149": {
+      "name": "NET_MAILBOX_GET_MAX_NUM_CHALLENGES",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x89F1B8CD": {
+      "name": "NET_MAILBOX_GET_NUM_CHALLENGES",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0xE85942F0": {
+      "name": "NET_MAILBOX_GET_CHALLENGE_BY_INDEX",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xD4FBCCE0": {
+      "name": "NET_MAILBOX_GET_CHALLENGE_BY_ID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xC9E96F78": {
+      "name": "NET_MAILBOX_IS_CHALLENGE_VALID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xCBBE41DD": {
+      "name": "SC_CHALLENGE_LAUNCH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xB7DE2AF2": {
+      "name": "SC_CHALLENGE_CLEAN_UP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x79F09AC7": {
+      "name": "SC_CHALLENGE_IS_RUNNING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x5D7197BC": {
+      "name": "SC_CHALLENGE_IS_ACTIVE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xFFC55DA4": {
+      "name": "SC_CHALLENGE_GET_COMMUNITY_TOTAL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xCEEEAE1D": {
+      "name": "SC_CHALLENGE_GET_COMMUNITY_VALUE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x1876B04E": {
+      "name": "SC_CHALLENGE_PROCESS_EXPIRATION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x4BD61354": {
+      "name": "SC_CHALLENGE_GET_EXPIRATION_STATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xF5F97702": {
+      "name": "SC_CHALLENGE_RESET_EXPIRATION_STATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xFD6197EB": {
+      "name": "SC_CHALLENGE_IS_VAR_VALID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xC322556E": {
+      "name": "SC_CHALLENGE_GET_VAR_FLOAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x2390DD18": {
+      "name": "SC_CHALLENGE_GET_VAR_INT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xB40622F1": {
+      "name": "SC_CHALLENGE_GET_VAR_BOOL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xD2513200": {
+      "name": "SC_CHALLENGE_RELEASE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xC21048BF": {
+      "name": "SC_CHALLENGE_GET_LEADERBOARD_ID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x5725C84F": {
+      "name": "SC_CHALLENGE_GET_MIN_LB_REFRESH_DELAY_SECS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x2374C1E0": {
+      "name": "SC_CHALLENGE_GET_MIN_SUBMIT_DELAY_SECS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    }
+  },
+  "GATEWAY": {
+    "0x820699A8": {
+      "name": "GATEWAY_GET_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x26D24123": {
+      "name": "GATEWAY_SET_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x987AD426": {
+      "name": "GATEWAY_GET_VOLUME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xB62A4FB1": {
+      "name": "GATEWAY_GET_MARKER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x96BD89B6": {
+      "name": "GATEWAY_UPDATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xF03CC7A7": {
+      "name": "ACTOR_DATA_GRAVITY_LIMIT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x620A3C17": {
+      "name": "GATEWAY_DISABLE",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x3AE1062C": {
+      "name": "GATEWAYS_ARE_DISABLED",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0xB9F2F8BB": {
+      "name": "GATEWAY_IS_DISABLED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    }
+  },
   "GRAVESTONE": {
     "0xF62EE158": {
       "name": "_0xF62EE158",
@@ -20311,9 +22214,9 @@
       "return_type": "Any"
     }
   },
-  "GATEWAY": {
-    "0x820699A8": {
-      "name": "GATEWAY_GET_ACTOR",
+  "GREETING": {
+    "0x9953D4FC": {
+      "name": "SET_GREETING_CONTEXT",
       "comment": "",
       "params": [
         {
@@ -20321,10 +22224,10 @@
           "name": "p0"
         }
       ],
-      "return_type": "Any"
+      "return_type": "int"
     },
-    "0x26D24123": {
-      "name": "GATEWAY_SET_ACTOR",
+    "0x751809BB": {
+      "name": "SET_NON_VERBAL_GREETING_PROBABILITY",
       "comment": "",
       "params": [
         {
@@ -20332,10 +22235,10 @@
           "name": "p0"
         }
       ],
-      "return_type": "Any"
+      "return_type": "void"
     },
-    "0x987AD426": {
-      "name": "GATEWAY_GET_VOLUME",
+    "0x25A42C69": {
+      "name": "_0x25A42C69",
       "comment": "",
       "params": [
         {
@@ -20343,68 +22246,10 @@
           "name": "p0"
         }
       ],
-      "return_type": "Any"
+      "return_type": "void"
     },
-    "0xB62A4FB1": {
-      "name": "GATEWAY_GET_MARKER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x96BD89B6": {
-      "name": "GATEWAY_UPDATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xF03CC7A7": {
-      "name": "ACTOR_DATA_GRAVITY_LIMIT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x620A3C17": {
-      "name": "GATEWAY_DISABLE",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x3AE1062C": {
-      "name": "GATEWAYS_ARE_DISABLED",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0xB9F2F8BB": {
-      "name": "GATEWAY_IS_DISABLED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    }
-  },
-  "AI_ATTENTION": {
-    "0x945F518F": {
-      "name": "_AIATTENTIONATTRACTOR",
+    "0x40121E4F": {
+      "name": "_0x40121E4F",
       "comment": "",
       "params": [
         {
@@ -20414,29 +22259,112 @@
         {
           "type": "Any",
           "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        },
-        {
-          "type": "float",
-          "name": "p4"
-        },
-        {
-          "type": "float",
-          "name": "p5"
-        },
-        {
-          "type": "float",
-          "name": "p6"
         }
       ],
-      "return_type": "int"
+      "return_type": "void"
+    },
+    "0x86CB8CFB": {
+      "name": "_0x86CB8CFB",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xD6AD0016": {
+      "name": "_0xD6AD0016",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xDE84B637": {
+      "name": "_0xDE84B637",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x8C00C0BE": {
+      "name": "_0x8C00C0BE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7CC67B30": {
+      "name": "_0x7CC67B30",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xD4ECD97D": {
+      "name": "_0xD4ECD97D",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x826BB889": {
+      "name": "_0x826BB889",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x5473B93A": {
+      "name": "_0x5473B93A",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x1B1EFCCB": {
+      "name": "_0x1B1EFCCB",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
     }
   },
   "GRINGO": {
@@ -23318,6 +25246,358 @@
       "return_type": "const char*"
     }
   },
+  "HEALTH": {
+    "0x2C0F211D": {
+      "name": "GET_LAST_ATTACKER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x3A207AF2": {
+      "name": "GET_LAST_HIT_TIME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x07B7AA6B": {
+      "name": "GET_LAST_HIT_WEAPON",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x08308EBA": {
+      "name": "GET_LAST_HIT_FLAGS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x45556269": {
+      "name": "GET_LAST_DAMAGE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x855F9A3B": {
+      "name": "GET_LAST_HIT_ZONE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any*",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x4747F219": {
+      "name": "GET_CORPSE_LAST_HIT_WEAPON",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0xF75FE17F": {
+      "name": "GET_CORPSE_LAST_HIT_ZONE",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x8D696237": {
+      "name": "CLEAR_LAST_HIT",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x8B08ECA2": {
+      "name": "KILL_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x6085F7AC": {
+      "name": "KILL_ACTOR_WITH_KILLER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x2F232639": {
+      "name": "IS_ACTOR_ALIVE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x0D798FFE": {
+      "name": "IS_ACTOR_DEAD",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x3918D335": {
+      "name": "IS_ACTOR_RAGDOLL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xFA090024": {
+      "name": "SET_ACTOR_HEALTH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "float",
+          "name": "health"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xF246F15D": {
+      "name": "GET_ACTOR_HEALTH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0xB69A84AF": {
+      "name": "GET_ACTOR_MAX_HEALTH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0x165BD4C5": {
+      "name": "SET_ACTOR_MAX_HEALTH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7A207FFE": {
+      "name": "_0x7A207FFE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x3A2D7759": {
+      "name": "SET_ACTOR_KO_POINTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x44787A58": {
+      "name": "GET_ACTOR_KO_POINTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xAFC96669": {
+      "name": "GET_ACTOR_MAX_KO_POINTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x4EEC6628": {
+      "name": "_SET_ACTOR_HEALTH_3",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x479B997B": {
+      "name": "_SET_ACTOR_HEALTH_4",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xFF07D58C": {
+      "name": "IS_ACTOR_DRUNK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x9F57742C": {
+      "name": "SET_ACTOR_DRUNK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "BOOL",
+          "name": "toggle"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x2A9FD09F": {
+      "name": "SET_ACTOR_PASSED_OUT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x5262C0F7": {
+      "name": "SET_ACTOR_HANGING_FROM_NOOSE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x6287203C": {
+      "name": "_0x6287203C",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x1082715D": {
+      "name": "_0x1082715D",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    }
+  },
   "HOLSTER": {
     "0xFE9903CC": {
       "name": "ACTOR_HOLSTER_WEAPON",
@@ -25831,9 +28111,998 @@
       "return_type": "void"
     }
   },
-  "WORLD2": {
-    "0x9CD3AD70": {
-      "name": "FIND_INTERSECTION",
+  "INVENTORY": {
+    "0xBAA5D41B": {
+      "name": "ADD_ITEM",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "ItemName"
+        },
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xAB2D8A68": {
+      "name": "ADD_ITEM_BY_CRC",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7609A328": {
+      "name": "HAS_INVENTORY_COMPONENT",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0xD91ED898": {
+      "name": "GET_ITEM_COUNT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x4BB2BC20": {
+      "name": "GET_ITEM_COUNT_BY_CRC",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xF52BA99F": {
+      "name": "GET_MAX_ITEM_COUNT",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0xE712FCB": {
+      "name": "SET_MAX_ITEM_COUNT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x5ACC0171": {
+      "name": "ADD_ACCESSORY",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xF750D150": {
+      "name": "ADD_ACCESSORY_BY_CRC",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xF05D1566": {
+      "name": "ADD_COLLECTABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x5889EBB7": {
+      "name": "REMOVE_COLLECTABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x2B00A643": {
+      "name": "READY_ITEM",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "ItemName"
+        },
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xB426267D": {
+      "name": "HAS_ITEM",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xC38F697": {
+      "name": "HAS_ACCESSORY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xEFECF4F9": {
+      "name": "DELETE_ITEM",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xD6A9C9D4": {
+      "name": "DELETE_ACCESSORY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7BF75BCE": {
+      "name": "_0x7BF75BCE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x7F4D5AE0": {
+      "name": "_0x7F4D5AE0",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x608DCAEF": {
+      "name": "_0x608DCAEF",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x50C0E83F": {
+      "name": "IS_ITEM_WEAPON_BY_CRC",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x3A899B0E": {
+      "name": "GET_ITEM_IN_HAND_EQUIPSLOT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x0E0EFB13": {
+      "name": "_GET_AN_EQUIP_SLOT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x5E38B33C": {
+      "name": "ACTOR_DISABLE_WEAPON_RENDER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x1511D111": {
+      "name": "ACTOR_FORCE_WEAPON_RENDER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xAB5FB5AC": {
+      "name": "IS_WEAPON_DRAWN",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x6AA0EAF2": {
+      "name": "GIVE_WEAPON_TO_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "int",
+          "name": "weaponId"
+        },
+        {
+          "type": "int",
+          "name": "ammoCount"
+        },
+        {
+          "type": "BOOL",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xBFD6D55F": {
+      "name": "ACTOR_SET_NEXT_WEAPON",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x8F4B473D": {
+      "name": "ACTOR_PUT_WEAPON_IN_HAND",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x09950C1B": {
+      "name": "ACTOR_HAS_WEAPON_IN_HAND",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x13A63AA7": {
+      "name": "ACTOR_PUT_ITEM_AWAY",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x78145528": {
+      "name": "_0x78145528",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x5CAFCBD4": {
+      "name": "_0x5CAFCBD4",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x3417766E": {
+      "name": "_0x3417766E",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0xCC02BBD3": {
+      "name": "_0xCC02BBD3",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0xA8040D70": {
+      "name": "_0xA8040D70",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x659532FB": {
+      "name": "ACTOR_GET_BEST_WEAPON_OF_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xCB017277": {
+      "name": "DELETE_WEAPON_FROM_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x42C0FAAA": {
+      "name": "GET_WEAPON_EQUIPPED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x6262DC5E": {
+      "name": "GET_WEAPON_IS_EXTERNALLY_CREATED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xA4B2016D": {
+      "name": "GET_WEAPON_IN_HAND",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xCDD6F94": {
+      "name": "GET_WEAPON_IN_HAND_CRC",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x612066E5": {
+      "name": "_0x612066E5",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x2776B0F5": {
+      "name": "GET_WEAPON_ENUM_FROM_CRC",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xFD46B231": {
+      "name": "ACTOR_USE_ITEM_NOW",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xE6604B39": {
+      "name": "SET_EQUIP_SLOT_ENABLED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xA3E18517": {
+      "name": "GET_EQUIP_SLOT_ENABLED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x5A80659D": {
+      "name": "EQUIP_ACCESSORY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xF7696B8B": {
+      "name": "DEEQUIP_ACCESSORY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x9B958A25": {
+      "name": "HAS_ACCESSORY_ENUM",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xE094DB31": {
+      "name": "_0xE094DB31",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x7FDDF876": {
+      "name": "DROP_ACCESSORY_ENUM",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x8266C617": {
+      "name": "ACTOR_SET_WEAPON_AMMO",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "int",
+          "name": "weaponId"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xB008EF49": {
+      "name": "ACTOR_SET_WEAPON_AMMO_BY_CRC",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x0D47CFBD": {
+      "name": "ACTOR_HAS_WEAPON",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xCC69DCC1": {
+      "name": "ACTOR_ADD_WEAPON_AMMO",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "int",
+          "name": "weaponId"
+        },
+        {
+          "type": "int",
+          "name": "ammo"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x43DEDFAE": {
+      "name": "ACTOR_GET_WEAPON_AMMO",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xEEC81873": {
+      "name": "ACTOR_DISCARD_WEAPON_AMMO",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xA091179F": {
+      "name": "ACTOR_HAS_VARIABLE_MESH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x17883570": {
+      "name": "GET_AMMOENUM_FOR_WEAPONENUM",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xA8F64D32": {
+      "name": "GET_WEAPONENUM_FOR_AMMOENUM",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xAE44869D": {
+      "name": "SET_WEAPON_GOLD",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "int",
+          "name": "weaponId"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x6DBD1DDB": {
+      "name": "GET_WEAPON_GOLD",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "int",
+          "name": "weapon"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x80B30545": {
+      "name": "IS_GOLDEN_GUNS_ON",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x195A4286": {
+      "name": "FIRE_PROJECTILE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "int",
+          "name": "weapGroup"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "Vector3*",
+          "name": "origin"
+        },
+        {
+          "type": "Vector3*",
+          "name": "target"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x98B3ABFA": {
+      "name": "_ADD_AMMO_OF_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x4372593E": {
+      "name": "_SET_ACTOR_AMMO_OF_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x6ADAAD87": {
+      "name": "_SET_ACTOR_MAX_AMMO_AMOUNT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4FE2B586": {
+      "name": "_SET_ACTOR_INFINITE_AMMO_FLAG",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "int",
+          "name": "weaponGroup"
+        },
+        {
+          "type": "BOOL",
+          "name": "toggle"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE224AC6F": {
+      "name": "IS_FRONTEND_DEATH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x7AB368CF": {
+      "name": "_GET_MAX_AMMO_AMOUNT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xC666B987": {
+      "name": "_GET_ACTOR_INFINITE_AMMO_FLAG",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xBE39208A": {
+      "name": "ACTOR_SHOULD_DROP_ITEMS_ON_DEATH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xBC46E3E1": {
+      "name": "ACTOR_SET_DROP_ITEM_ON_DEATH_ENUMERATED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xBF0235B0": {
+      "name": "CREATE_WEAPON_PICKUP",
       "comment": "",
       "params": [
         {
@@ -25859,43 +29128,36 @@
         {
           "type": "Any",
           "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
         }
       ],
       "return_type": "Any"
     },
-    "0x6AD8EEAF": {
-      "name": "FIND_GROUND_INTERSECTION",
+    "0x04BF00F0": {
+      "name": "REMOVE_ALL_PICKUPS",
       "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
+      "params": [],
+      "return_type": "void"
+    },
+    "0x118D085E": {
+      "name": "GET_NUM_WEAPONS_IN_INVENTORY",
+      "comment": "",
+      "params": [],
       "return_type": "Any"
     },
-    "0x77964B0C": {
-      "name": "FIND_GROUND_INTERSECTION_WITH_MATERIAL",
+    "0x78A3CD3D": {
+      "name": "_0x78A3CD3D",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x2C23CBE7": {
+      "name": "_0x2C23CBE7",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0xD695F857": {
+      "name": "_REMOVE_WEAPON",
       "comment": "",
       "params": [
         {
@@ -25903,10 +29165,49 @@
           "name": "p0"
         }
       ],
+      "return_type": "void"
+    },
+    "0x96AC812B": {
+      "name": "_0x96AC812B",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
       "return_type": "Any"
     },
-    "0x4F193BE4": {
-      "name": "FIND_WATER_INTERSECTION",
+    "0x5AEB2E4F": {
+      "name": "_REMOVE_HAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x3E8E7D7B": {
+      "name": "SETUP_ASSOCIATED_FRAGMENTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x7BF01CCB": {
+      "name": "_0x7BF01CCB",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x8EA46104": {
+      "name": "_0x8EA46104",
       "comment": "",
       "params": [
         {
@@ -25928,53 +29229,14 @@
         {
           "type": "Any",
           "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
         }
       ],
       "return_type": "Any"
     },
-    "0x5219B7D0": {
-      "name": "GET_MATERIAL_AT_VECTOR",
+    "0xD2A140BC": {
+      "name": "_0xD2A140BC",
       "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x451A8EF2": {
-      "name": "GET_ACTOR_GROUND_MATERIAL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x1E81DB60": {
-      "name": "IS_POSITION_INDOORS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
+      "params": [],
       "return_type": "Any"
     }
   },
@@ -27132,6 +30394,3414 @@
         }
       ],
       "return_type": "Any"
+    }
+  },
+  "LEASH": {
+    "0x9BCC06E2": {
+      "name": "CREATE_LEASH_OBJECT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8EA68EB5": {
+      "name": "LEASH_CONSTRAIN",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE58339B3": {
+      "name": "LEASH_RESTART",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x7F190CA3": {
+      "name": "LEASH_SET_CONSTRAINT_LENGTH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x14BEC6F5": {
+      "name": "LEASH_SET_LEASH_LENGTH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7A1376B0": {
+      "name": "LEASH_RELEASE_CONSTRAINT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x0FCDB481": {
+      "name": "LEASH_ATTACH_TO_WORLD",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x35D8B21E": {
+      "name": "LEASH_ATTACH_TO_OBJECT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        },
+        {
+          "type": "Any",
+          "name": "p9"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE782EB20": {
+      "name": "LEASH_ATTACH_TO_FRAGMENT_LOCATOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        },
+        {
+          "type": "Any",
+          "name": "p9"
+        },
+        {
+          "type": "Any",
+          "name": "p10"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x82A73B3D": {
+      "name": "LEASH_ATTACH_TO_OBJECT_BONE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        },
+        {
+          "type": "Any",
+          "name": "p9"
+        },
+        {
+          "type": "Any",
+          "name": "p10"
+        },
+        {
+          "type": "Any",
+          "name": "p11"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x4B67B8BB": {
+      "name": "LEASH_ATTACH_TO_OBJECT_BONE_VISUAL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        },
+        {
+          "type": "Any",
+          "name": "p9"
+        },
+        {
+          "type": "Any",
+          "name": "p10"
+        },
+        {
+          "type": "Any",
+          "name": "p11"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC1265E7F": {
+      "name": "_0xC1265E7F",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        },
+        {
+          "type": "float",
+          "name": "p4"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x951B8DF7": {
+      "name": "LEASH_DETACH_OBJECT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x46BE1D43": {
+      "name": "LEASH_IS_BROKEN",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8640261B": {
+      "name": "LEASH_BREAK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xC039BBF1": {
+      "name": "CREATE_ROPE_FOR_BRIDGE_LEFT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x51CF9A54": {
+      "name": "CREATE_ROPE_FOR_BRIDGE_RIGHT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5A72DD49": {
+      "name": "LEASH_STAY_CONSTRAINED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x1A8494E6": {
+      "name": "SET_LEASH_COLLIDES",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    }
+  },
+  "MINIGAME": {
+    "0xE8184916": {
+      "name": "START_MINIGAME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE2B894D1": {
+      "name": "PUSH_MINIGAME_INPUT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x117D7E71": {
+      "name": "IS_MINIGAME_RUNNING",
+      "comment": "",
+      "params": [],
+      "return_type": "BOOL"
+    },
+    "0xCA746CD2": {
+      "name": "END_CURRENT_MINIGAME",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x6AAD0420": {
+      "name": "_0x6AAD0420",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x655D350B": {
+      "name": "_0x655D350B",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x0627DDEC": {
+      "name": "SET_CURRENT_MINIGAME_INT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x2DC768BB": {
+      "name": "_0x2DC768BB",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8275FDD4": {
+      "name": "_0x8275FDD4",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    }
+  },
+  "MISC": {
+    "0x11069324": {
+      "name": "CREATE_OBJECT_LOCATOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x0B24362F": {
+      "name": "_0x0B24362F",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        },
+        {
+          "type": "float",
+          "name": "p4"
+        },
+        {
+          "type": "float",
+          "name": "p5"
+        },
+        {
+          "type": "float",
+          "name": "p6"
+        },
+        {
+          "type": "float",
+          "name": "p7"
+        },
+        {
+          "type": "float",
+          "name": "p8"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE25F407D": {
+      "name": "_0xE25F407D",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        },
+        {
+          "type": "float",
+          "name": "p4"
+        },
+        {
+          "type": "float",
+          "name": "p5"
+        },
+        {
+          "type": "float",
+          "name": "p6"
+        },
+        {
+          "type": "float",
+          "name": "p7"
+        },
+        {
+          "type": "float",
+          "name": "p8"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xEB33480A": {
+      "name": "_0xEB33480A",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        },
+        {
+          "type": "float",
+          "name": "p4"
+        },
+        {
+          "type": "float",
+          "name": "p5"
+        },
+        {
+          "type": "float",
+          "name": "p6"
+        },
+        {
+          "type": "float",
+          "name": "p7"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x88F7432C": {
+      "name": "_0x88F7432C",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x04507DBC": {
+      "name": "_0x04507DBC",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    }
+  },
+  "MIXER": {
+    "0xECD8E116": {
+      "name": "DYNAMICMIXER_TRIGGERSTATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xA82D893C": {
+      "name": "DYNAMICMIXER_TRIGGERSTATE_PERSISTENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "int*",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xF86010D1": {
+      "name": "DYNAMICMIXER_DETRIGGERSTATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xADCC16A2": {
+      "name": "_DYNAMICMIXER_2",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    }
+  },
+  "MOTIVE": {
+    "0x1BED8493": {
+      "name": "SET_MOTIVE_BY_ENUM",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    }
+  },
+  "MOVIE": {
+    "0x92028B49": {
+      "name": "WORLD_MOVIE_PLAYER",
+      "comment": "Not in PS4/Switch/PC",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7614AEBA": {
+      "name": "_0x7614AEBA",
+      "comment": "PS4/Switch/PC only",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x69FC319E": {
+      "name": "_0x69FC319E",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xD036DF91": {
+      "name": "_0xD036DF91",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    }
+  },
+  "NAVMESH": {
+    "0x8A0D3339": {
+      "name": "STREAMING_IS_MOVABLE_NAV_MESH_RESIDENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x63334F63": {
+      "name": "STREAMING_REQUEST_MOVABLE_NAV_MESH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xC329E1DB": {
+      "name": "STREAMING_UNREQUEST_MOVABLE_NAV_MESH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xECEE9E20": {
+      "name": "SET_ACTOR_MOVABLE_NAV_MESH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    }
+  },
+  "NAVQUERY": {
+    "0xE2F41226": {
+      "name": "CREATE_NAV_QUERY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xE96D01E5": {
+      "name": "NAV_QUERY_IS_DONE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5A511344": {
+      "name": "NAV_QUERY_CAN_PATH_TO_POINT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xAFA35FFA": {
+      "name": "NAV_QUERY_RECEIVE_CAN_PATH_TO_POINT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x07A777D7": {
+      "name": "NAV_QUERY_START_CAN_PATH_TO_POINT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x50290FB3": {
+      "name": "NAV_QUERY_STOP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    }
+  },
+  "NET": {
+    "0x6BCFE549": {
+      "name": "NET_SET_TUNING_PARAM",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int*"
+    },
+    "0x50E637D7": {
+      "name": "_0x50E637D7",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x48275716": {
+      "name": "NET_LOG",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xD164026F": {
+      "name": "NET_DUMP_STATE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x9180FF1C": {
+      "name": "NET_ENABLE_MULTIPLAYER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x84B0B5D6": {
+      "name": "NET_IS_MANAGER_INITIALIZED",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x8CA54980": {
+      "name": "NET_IS_IN_SESSION",
+      "comment": "",
+      "params": [],
+      "return_type": "BOOL"
+    },
+    "0x5FF2BAE0": {
+      "name": "NET_IS_ONLINE_AVAILABLE",
+      "comment": "",
+      "params": [],
+      "return_type": "BOOL"
+    },
+    "0x7AB722D8": {
+      "name": "NET_IS_CONNECTED_FOR_PLAY",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xBC4B6B74": {
+      "name": "NET_GET_PLAYMODE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x18EC9CF0": {
+      "name": "NET_APPLY_PROTOCOL_MASK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x17D14553": {
+      "name": "NET_SET_SOCIAL_CLUB_URLS",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "result"
+        },
+        {
+          "type": "const char*",
+          "name": "p1"
+        },
+        {
+          "type": "Any*",
+          "name": "p2"
+        }
+      ],
+      "return_type": "const char*"
+    },
+    "0xCDAC0F0E": {
+      "name": "NET_IS_SESSION_HOST",
+      "comment": "",
+      "params": [],
+      "return_type": "BOOL"
+    },
+    "0xFF65A07C": {
+      "name": "NET_IS_SESSION_CLIENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x75DD203B": {
+      "name": "NET_GET_MAC_ADDRESS32",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x31700C0A": {
+      "name": "NET_GET_NAT_TYPE",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x0678A865": {
+      "name": "NET_IS_BUSY",
+      "comment": "",
+      "params": [],
+      "return_type": "BOOL"
+    },
+    "0xFF8DA25D": {
+      "name": "NET_GET_NET_TIME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xB829A92D": {
+      "name": "NET_ENABLE_KICKING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x71D989BD": {
+      "name": "NET_IS_LOCAL_GAMER_ONLINE",
+      "comment": "",
+      "params": [],
+      "return_type": "BOOL"
+    },
+    "0x95CDCE7A": {
+      "name": "NET_GET_LOCAL_GAMER_NAME",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0xAD85A378": {
+      "name": "NET_APPLY_RELEVANCY_OVERRIDE",
+      "comment": "",
+      "params": [],
+      "return_type": "int*"
+    },
+    "0x72B03551": {
+      "name": "NET_CLEAR_RELEVANCY_OVERRIDE",
+      "comment": "",
+      "params": [],
+      "return_type": "int*"
+    },
+    "0x860FCDBD": {
+      "name": "GET_SLOT_FOR_HOST",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x0F99A8BC": {
+      "name": "GET_NUM_PLAYERS",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x84D6F8A7": {
+      "name": "NET_START_NEW_SCRIPT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5E985228": {
+      "name": "NET_SCRIPTMSG_SEND",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "channelId"
+        },
+        {
+          "type": "int",
+          "name": "headerSize"
+        },
+        {
+          "type": "int*",
+          "name": "buffer"
+        },
+        {
+          "type": "int",
+          "name": "count"
+        },
+        {
+          "type": "bool",
+          "name": "pushToQueue"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xE2163ECC": {
+      "name": "NET_SCRIPTMSG_ISPENDING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xB13DD691": {
+      "name": "NET_SCRIPTMSG_GETNEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x9253CC79": {
+      "name": "NET_SCRIPTMSG_REGISTER_HANDLER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x4957E482": {
+      "name": "NET_SCRIPTMSG_QUERY_HANDLER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xBEDD194D": {
+      "name": "REGISTER_HOST_BROADCAST_VARIABLES",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xF1732769": {
+      "name": "REGISTER_CLIENT_BROADCAST_VARIABLES",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x2707F082": {
+      "name": "UNREGISTER_HOST_BROADCAST_VARIABLES",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x0130DB5D": {
+      "name": "UNREGISTER_CLIENT_BROADCAST_VARIABLES",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0xF81E2097": {
+      "name": "_IS_CLIENT_DATA_VALID_FOR_SLOT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x64C2DD40": {
+      "name": "_IS_CLIENT_DATA_VALID_FOR_SLOT_2",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xA80C6DE6": {
+      "name": "_0xA80C6DE6",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xD12C55A5": {
+      "name": "NET_IS_OBJECT_LOCAL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x68EC589D": {
+      "name": "NET_REQUEST_OBJECT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x47C5E353": {
+      "name": "_0x47C5E353",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x3932B786": {
+      "name": "_0x3932B786",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "result"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x138F38AC": {
+      "name": "NET_OBJECT_GET_REPLICATION_MODE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x3E509DF1": {
+      "name": "NET_OBJECT_SET_REPLICATION_MODE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8C7E41E2": {
+      "name": "NET_OBJECT_LOCK_OWNERSHIP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x1306549E": {
+      "name": "_0x1306549E",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5C4CAE3A": {
+      "name": "_0x5C4CAE3A",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int*"
+    },
+    "0x579C2014": {
+      "name": "_0x579C2014",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7837890B": {
+      "name": "_NET_SET_EQUIP_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xA6D794FE": {
+      "name": "_0xA6D794FE",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "result"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x1C147E14": {
+      "name": "_0x1C147E14",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "result"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xCA6231C1": {
+      "name": "_0xCA6231C1",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC09B114B": {
+      "name": "_NET_ACTOR_OBJECT_ID",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "result"
+        },
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7284A71B": {
+      "name": "_NET_ACTOR_OBJECT_ID_2",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "result"
+        },
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7AB65B0C": {
+      "name": "NET_GET_SESSION_GAMER_COUNT",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xCAA24B1A": {
+      "name": "AWARD_ACHIEVEMENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x136A5BE9": {
+      "name": "HAS_ACHIEVEMENT_BEEN_PASSED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xC792A9E0": {
+      "name": "ARE_ACHIEVEMENTS_READY",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xDD33E221": {
+      "name": "AWARD_AVATAR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xC4F9DA6E": {
+      "name": "NET_GET_POSSE_COUNT",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x1CAD6D29": {
+      "name": "NET_IS_POSSE_LEADER",
+      "comment": "",
+      "params": [],
+      "return_type": "BOOL"
+    },
+    "0x0D914C89": {
+      "name": "NET_GET_POSSE_LEADER_SLOT",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xFC52BD15": {
+      "name": "NET_GET_GAMER_POSSE_LEADER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xB6006EA9": {
+      "name": "NET_GET_GAMER_POSSE_SIZE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x98A5CDC5": {
+      "name": "NET_POSSE_REMOVE_GAMER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x106CE441": {
+      "name": "_0x106CE441",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x6A7B9FAD": {
+      "name": "_0x6A7B9FAD",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x2037A74F": {
+      "name": "NET_RUN_SEARCH_BOT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x89D8FC30": {
+      "name": "NET_GET_NUMBER_OF_SESSIONS",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x2010ABE6": {
+      "name": "NET_IS_SEARCHBOT_BUSY",
+      "comment": "",
+      "params": [],
+      "return_type": "BOOL"
+    },
+    "0xF6E40FF3": {
+      "name": "_0xF6E40FF3",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC0849D70": {
+      "name": "_0xC0849D70",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x8DF05A4F": {
+      "name": "_0x8DF05A4F",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x4AE5DBB2": {
+      "name": "NET_SESSION_LEAVE_SESSION",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x80B20614": {
+      "name": "NET_IS_FACTION_SAFE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x86FF3A9B": {
+      "name": "NET_SESSION_START_GAMEPLAY",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x81FD9851": {
+      "name": "NET_SESSION_END_GAMEPLAY",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x3A5C56E3": {
+      "name": "NET_SESSION_SET_INVITABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xFA0E1F8B": {
+      "name": "_0xFA0E1F8B",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xCC7D0431": {
+      "name": "_0xCC7D0431",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xDC88B308": {
+      "name": "NET_SESSION_IS_GAMEPLAY_STARTED",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xD923CD1B": {
+      "name": "_0xD923CD1B",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7540959C": {
+      "name": "_NET_REQUEST_BECOME_GAME_HOST",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xEE3B79EE": {
+      "name": "NET_SET_THIS_SCRIPT_IS_NET_SCRIPT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4238C471": {
+      "name": "NET_UNREGISTER_AS_NET_SCRIPT",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x667DA125": {
+      "name": "NET_GET_SCRIPT_STATUS",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x110A9B2F": {
+      "name": "NET_IS_PLAYER_PARTICIPANT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Player",
+          "name": "player"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x6D403720": {
+      "name": "NET_IS_HOST_OF_THIS_SCRIPT",
+      "comment": "",
+      "params": [],
+      "return_type": "BOOL"
+    },
+    "0x9272C3BA": {
+      "name": "NET_GET_HOST_OF_THIS_SCRIPT",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0x408E28E2": {
+      "name": "NET_ALLOW_PLAYERS_TO_JOIN",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC0FC4B57": {
+      "name": "NET_IS_SCRIPT_REGISTERED_AS_NET_SCRIPT",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xD9965A9A": {
+      "name": "NET_SCRIPT_GET_NUM_PARTICIPANTS",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x7BDCBD45": {
+      "name": "SET_RICH_PRESENCE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x50C18480": {
+      "name": "_0x50C18480",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE5645CB3": {
+      "name": "_0xE5645CB3",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x79AFAB1F": {
+      "name": "_0x79AFAB1F",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        },
+        {
+          "type": "Any",
+          "name": "p9"
+        },
+        {
+          "type": "Any",
+          "name": "p10"
+        },
+        {
+          "type": "Any",
+          "name": "p11"
+        },
+        {
+          "type": "Any",
+          "name": "p12"
+        },
+        {
+          "type": "Any",
+          "name": "p13"
+        },
+        {
+          "type": "Any",
+          "name": "p14"
+        },
+        {
+          "type": "Any",
+          "name": "p15"
+        },
+        {
+          "type": "Any",
+          "name": "p16"
+        },
+        {
+          "type": "Any",
+          "name": "p17"
+        },
+        {
+          "type": "Any",
+          "name": "p18"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x581CAC89": {
+      "name": "_0x581CAC89",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xA174152C": {
+      "name": "_0xA174152C",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x0183A3F0": {
+      "name": "_0x0183A3F0",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x63034F52": {
+      "name": "_0x63034F52",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE9EAC45C": {
+      "name": "_0xE9EAC45C",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xBDF22FCA": {
+      "name": "IS_SESSION_CURRENTLY_JOINED_SESSION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x9EA132A3": {
+      "name": "_0x9EA132A3",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xCB0BCAE2": {
+      "name": "NET_SESSION_SET_GAME_MODE_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7A99E7DE": {
+      "name": "NET_VOICE_BROADCAST_ENABLE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x1D5E39A0": {
+      "name": "NET_VOICE_BROADCAST_DISABLE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xEF6BF96E": {
+      "name": "NET_ARE_UNLOCKS_READY",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xC8B680B3": {
+      "name": "NET_IS_UNLOCKED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xBE0E275F": {
+      "name": "NET_GET_OVERLOAD_STATE_FOR_SLOT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xCB42389E": {
+      "name": "NET_GET_AREA_OVERLOAD_STATE_FOR_SLOT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x842ADE0A": {
+      "name": "_0x842ADE0A",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xB7856424": {
+      "name": "NET_SET_SYNC_PRIORITY_LIMITS",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xF2FA1DE8": {
+      "name": "UPDATE_PROFILE_STAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xCF674E31": {
+      "name": "UPDATE_STRING_PROFILE_STAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x97F15B69": {
+      "name": "_AH_LAG_HACK_KILL_PROTECTION_ENABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xCA0739A8": {
+      "name": "_AH_LAG_HACK_MOVE_PROTECTION_ENABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x49BC0219": {
+      "name": "NET_BROADCAST_EXPLODE_TARGET_EVENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xD6780B56": {
+      "name": "DO_FILE_CRC",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x9A5841E5": {
+      "name": "FLAG_FILE_CRC_MISMATCH",
+      "comment": "",
+      "params": [],
+      "return_type": "int*"
+    },
+    "0x489A2B93": {
+      "name": "NET_SET_UNLOCK",
+      "comment": "PS4/Switch/PC only",
+      "params": [],
+      "return_type": "int*"
+    }
+  },
+  "NET2": {
+    "0x55C5BB93": {
+      "name": "_0x55C5BB93",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xFAD5A270": {
+      "name": "_0xFAD5A270",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x4A721118": {
+      "name": "GAME_INSTANCE_ITERATOR_START",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x4500B98A": {
+      "name": "GAME_INSTANCE_ITERATOR_NEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x85049505": {
+      "name": "_0x85049505",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5C51D43C": {
+      "name": "ADD_PLAYLIST_TO_DB",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x0E2C4B68": {
+      "name": "GET_PLAYLIST_FROM_DB",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xB514ECA7": {
+      "name": "GET_PLAYLIST_FROM_DB_BY_NAME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    }
+  },
+  "NET_STATS": {
+    "0x12304873": {
+      "name": "NET_UPDATE_LEADERBOARD",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4D0C8AA4": {
+      "name": "_0x4D0C8AA4",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x89277EA3": {
+      "name": "_0x89277EA3",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x2B8F86ED": {
+      "name": "NET_CREATE_FRIEND_SCORE_READER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x88249424": {
+      "name": "NET_REPORT_FRIEND_SCORES",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x87A3A38D": {
+      "name": "_0x87A3A38D",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xD7572C68": {
+      "name": "_0xD7572C68",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x76F09F04": {
+      "name": "_0x76F09F04",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xA684E813": {
+      "name": "_0xA684E813",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xE5C5CE63": {
+      "name": "_0xE5C5CE63",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x4F652A00": {
+      "name": "_0x4F652A00",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xFC564903": {
+      "name": "_0xFC564903",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x7154D15B": {
+      "name": "_0x7154D15B",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x86BC0A55": {
+      "name": "_0x86BC0A55",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xEB4A6D85": {
+      "name": "_0xEB4A6D85",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x5FD52711": {
+      "name": "_0x5FD52711",
+      "comment": "",
+      "params": [],
+      "return_type": "BOOL"
+    },
+    "0xD0808C42": {
+      "name": "_0xD0808C42",
+      "comment": "",
+      "params": [],
+      "return_type": "BOOL"
+    },
+    "0x097BB984": {
+      "name": "_0x097BB984",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xEA7ADF42": {
+      "name": "_0xEA7ADF42",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x3A8C77AD": {
+      "name": "_0x3A8C77AD",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE89C6E4F": {
+      "name": "_0xE89C6E4F",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x0791F35A": {
+      "name": "_0x0791F35A",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x49C2B05F": {
+      "name": "_0x49C2B05F",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC813DBEF": {
+      "name": "_0xC813DBEF",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xE6B4F505": {
+      "name": "_0xE6B4F505",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x70AF0351": {
+      "name": "_0x70AF0351",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x293C3288": {
+      "name": "_0x293C3288",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xA7F231B0": {
+      "name": "_0xA7F231B0",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x984749B4": {
+      "name": "_0x984749B4",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    }
+  },
+  "NET_UI": {
+    "0x8808546E": {
+      "name": "NET_GET_AND_CLEAR_GAME_MODE_REQUEST",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x1A47001B": {
+      "name": "NET_GET_AND_CLEAR_PLAYLIST_REQUEST",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x0FF6B8F4": {
+      "name": "NET_GET_AND_CLEAR_QUIT_GAME_REQUEST",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x81F24788": {
+      "name": "NET_GET_FREE_ROAM_MODE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x41921C98": {
+      "name": "NET_SET_FREE_ROAM_MODE",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "mode"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE822010A": {
+      "name": "NET_REGISTER_GAME_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xA9459BB6": {
+      "name": "NET_REGISTER_PLAYLIST_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x9D9784B8": {
+      "name": "NET_SET_PLAYLIST_LOCKED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x03962973": {
+      "name": "_0x03962973",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x8E0D7219": {
+      "name": "NET_AUTHENTICATE_GAMER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC00C8C94": {
+      "name": "_0xC00C8C94",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x9BC05C90": {
+      "name": "_0x9BC05C90",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x97931B87": {
+      "name": "NET_GET_GAMER_RGB_COLOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xFE83A4FE": {
+      "name": "_0xFE83A4FE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8DEC3E03": {
+      "name": "_0x8DEC3E03",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xBECB3EEC": {
+      "name": "NET_PLAYER_BARKER_RESET",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x75F27D60": {
+      "name": "NET_GET_USING_SPHERE_CURVES",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xA64A451E": {
+      "name": "NET_PLAYER_SHOW_CONTEXT_MENU",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x67031EDA": {
+      "name": "NET_PLAYER_LIST_RESET",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xFD355ED1": {
+      "name": "NET_PLAYER_LIST_ADD_ITEM",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "text"
+        },
+        {
+          "type": "int",
+          "name": "rowIndex"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x805AC16A": {
+      "name": "NET_PLAYER_LIST_ADD_GAMER_SLOT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x0AAE9E6B": {
+      "name": "NET_PLAYER_LIST_SET_HIGHLIGHT",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "highlightIndex"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x20B684AB": {
+      "name": "NET_PLAYER_LIST_SET_TOP_TEAM",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x84CD0651": {
+      "name": "NET_PLAYER_LIST_SET_TEAM_SCORE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xA56B459C": {
+      "name": "NET_PLAYER_LIST_SET_TEAM_SORT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x0547A660": {
+      "name": "NET_PLAYER_LIST_SET_TITLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "gxtName"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xD6111569": {
+      "name": "NET_PLAYER_LIST_SET_TEMPLATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "menuTemplate"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xFA382FCB": {
+      "name": "NET_PLAYER_LIST_SET_HEADER",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "columnIndex"
+        },
+        {
+          "type": "const char*",
+          "name": "entry"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xCF065186": {
+      "name": "NET_PLAYER_LIST_SET_DESCRIPTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "str"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xBE7965C8": {
+      "name": "NET_PLAYER_LIST_TIMER_SET",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xD4C7E0D5": {
+      "name": "_0xD4C7E0D5",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x98FC68AF": {
+      "name": "NET_PLAYER_LIST_SET_CURRENT_ITEM",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x95A543E2": {
+      "name": "NET_PLAYER_LIST_SET_CURRENT_ITEM_BY_SLOT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC673362C": {
+      "name": "NET_PLAYER_LIST_SET_CURRENT_ITEM_MSCORE_STRING",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "columnIndex"
+        },
+        {
+          "type": "const char*",
+          "name": "text"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xEC6F465F": {
+      "name": "NET_PLAYER_LIST_SET_CURRENT_ITEM_MSCORE_INT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x794F5C21": {
+      "name": "NET_PLAYER_LIST_SET_CURRENT_ITEM_TEAM",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "groupColor"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xBD42097A": {
+      "name": "NET_PLAYER_LIST_SET_CURRENT_ITEM_PRIORITY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC09ACD5C": {
+      "name": "NET_PLAYER_LIST_SET_CURRENT_ITEM_DEAD",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC73DAD2B": {
+      "name": "NET_TICKER_REPORTF",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "text1"
+        },
+        {
+          "type": "const char*",
+          "name": "text2"
+        },
+        {
+          "type": "const char*",
+          "name": "text3"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8A1D83F2": {
+      "name": "NET_TICKER_CLEAR",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xA6403262": {
+      "name": "_0xA6403262",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x27D40FD1": {
+      "name": "NET_SCOREGRAPH_SETUP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xA3AE09EF": {
+      "name": "NET_SCOREGRAPH_CLEAR_MARKERS",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x746897AB": {
+      "name": "NET_SCOREGRAPH_ADD_PLAYER_SCORE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xB4C867BD": {
+      "name": "NET_SCOREGRAPH_ADD_PLAYER_LABEL",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x12558DBD": {
+      "name": "NET_SCOREGRAPH_ADD_TEAM_SCORE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x134AAF17": {
+      "name": "NET_SCOREGRAPH_ADD_TEAM_LABEL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
     }
   },
   "OBJECT": {
@@ -33072,1718 +39742,9 @@
       "return_type": "int"
     }
   },
-  "LEASH": {
-    "0x9BCC06E2": {
-      "name": "CREATE_LEASH_OBJECT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8EA68EB5": {
-      "name": "LEASH_CONSTRAIN",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE58339B3": {
-      "name": "LEASH_RESTART",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x7F190CA3": {
-      "name": "LEASH_SET_CONSTRAINT_LENGTH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x14BEC6F5": {
-      "name": "LEASH_SET_LEASH_LENGTH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7A1376B0": {
-      "name": "LEASH_RELEASE_CONSTRAINT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x0FCDB481": {
-      "name": "LEASH_ATTACH_TO_WORLD",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x35D8B21E": {
-      "name": "LEASH_ATTACH_TO_OBJECT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        },
-        {
-          "type": "Any",
-          "name": "p9"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE782EB20": {
-      "name": "LEASH_ATTACH_TO_FRAGMENT_LOCATOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        },
-        {
-          "type": "Any",
-          "name": "p9"
-        },
-        {
-          "type": "Any",
-          "name": "p10"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x82A73B3D": {
-      "name": "LEASH_ATTACH_TO_OBJECT_BONE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        },
-        {
-          "type": "Any",
-          "name": "p9"
-        },
-        {
-          "type": "Any",
-          "name": "p10"
-        },
-        {
-          "type": "Any",
-          "name": "p11"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x4B67B8BB": {
-      "name": "LEASH_ATTACH_TO_OBJECT_BONE_VISUAL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        },
-        {
-          "type": "Any",
-          "name": "p9"
-        },
-        {
-          "type": "Any",
-          "name": "p10"
-        },
-        {
-          "type": "Any",
-          "name": "p11"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC1265E7F": {
-      "name": "_0xC1265E7F",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        },
-        {
-          "type": "float",
-          "name": "p4"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x951B8DF7": {
-      "name": "LEASH_DETACH_OBJECT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x46BE1D43": {
-      "name": "LEASH_IS_BROKEN",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8640261B": {
-      "name": "LEASH_BREAK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xC039BBF1": {
-      "name": "CREATE_ROPE_FOR_BRIDGE_LEFT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x51CF9A54": {
-      "name": "CREATE_ROPE_FOR_BRIDGE_RIGHT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5A72DD49": {
-      "name": "LEASH_STAY_CONSTRAINED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x1A8494E6": {
-      "name": "SET_LEASH_COLLIDES",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    }
-  },
-  "AI_MEMORY": {
-    "0x8CD37E9E": {
-      "name": "MEMORY_CLEAR_EVENTS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4485B246": {
-      "name": "MEMORY_CLEAR_ALL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xACD4084D": {
-      "name": "MEMORY_CONSIDER_ACCORDING_TO_FACTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x296C01A4": {
-      "name": "MEMORY_CONSIDER_AS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x745A1BA3": {
-      "name": "MEMORY_CONSIDER_AS_ENEMY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0810A7BA": {
-      "name": "MEMORY_GET_IS_IDENTIFIED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x45CE40FD": {
-      "name": "MEMORY_GET_IS_VISIBLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC407497F": {
-      "name": "MEMORY_GET_WAS_VISIBLE_WITHIN_TIME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xBA09085C": {
-      "name": "MEMORY_IDENTIFY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x052CC7CE": {
-      "name": "MEMORY_REPORT_POSITION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x2F589CDF": {
-      "name": "MEMORY_REPORT_POSITION_AUTO",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x05B3D34F": {
-      "name": "MEMORY_GET_MUST_IDENTIFY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5A83A1EA": {
-      "name": "MEMORY_ATTACK_ON_SIGHT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x48AA959E": {
-      "name": "MEMORY_CLEAR_RIDING_PREFERENCE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x1B72B0DD": {
-      "name": "MEMORY_PREFER_RIDING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x2F7B60A4": {
-      "name": "MEMORY_PREFER_WALKING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x2F929ECD": {
-      "name": "MEMORY_PREFER_MELEE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xC175F2B5": {
-      "name": "MEMORY_FORCE_MELEE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x937E1760": {
-      "name": "MEMORY_ALLOW_SHOOTING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE944E5F8": {
-      "name": "MEMORY_ALLOW_TAKE_COVER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xDBDB57D0": {
-      "name": "MEMORY_ALLOW_THROWING_EXPLOSIVES",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x5DD0AC4A": {
-      "name": "MEMORY_ALLOW_PICKUP_WEAPONS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x009EB4C1": {
-      "name": "MEMORY_GET_WEAPON_DRAW_PREFERENCE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xDD965D74": {
-      "name": "MEMORY_CLEAR_WEAPON_DRAW_PREFERENCE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xF8CB6260": {
-      "name": "MEMORY_SET_WEAPON_DRAW_PREFERENCE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x7E77DD6C": {
-      "name": "MEMORY_GET_POSITION_LAST_KNOWN_TIME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7EDD316C": {
-      "name": "MEMORY_EVERYBODY_FORGET_ABOUT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xD1628C57": {
-      "name": "MEMORY_EVERYBODY_FORGET_ABOUT_EVERYTHING",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x052E865C": {
-      "name": "MEMORY_SHOULD_ALWAYS_PATHFIND_IN_FORMATION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xAF94B7D9": {
-      "name": "AI_GLOBAL_CLEAR_ALL_DANGER",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0xB6FCFFAA": {
-      "name": "AI_GLOBAL_CLEAR_DANGER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xFF00B4E6": {
-      "name": "AI_GLOBAL_GET_PERMANENT_DANGER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5EC098F2": {
-      "name": "AI_GLOBAL_IS_DANGER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x64C177FB": {
-      "name": "AI_GLOBAL_SET_PERMANENT_DANGER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xCF70330C": {
-      "name": "AI_GLOBAL_REPORT_DANGER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xB4621962": {
-      "name": "MEMORY_SET_UNARMED_RETREAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    }
-  },
-  "MINIGAME": {
-    "0xE8184916": {
-      "name": "START_MINIGAME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE2B894D1": {
-      "name": "PUSH_MINIGAME_INPUT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x117D7E71": {
-      "name": "IS_MINIGAME_RUNNING",
-      "comment": "",
-      "params": [],
-      "return_type": "BOOL"
-    },
-    "0xCA746CD2": {
-      "name": "END_CURRENT_MINIGAME",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x6AAD0420": {
-      "name": "_0x6AAD0420",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x655D350B": {
-      "name": "_0x655D350B",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x0627DDEC": {
-      "name": "SET_CURRENT_MINIGAME_INT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x2DC768BB": {
-      "name": "_0x2DC768BB",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8275FDD4": {
-      "name": "_0x8275FDD4",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    }
-  },
-  "MIXER": {
-    "0xECD8E116": {
-      "name": "DYNAMICMIXER_TRIGGERSTATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xA82D893C": {
-      "name": "DYNAMICMIXER_TRIGGERSTATE_PERSISTENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "int*",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xF86010D1": {
-      "name": "DYNAMICMIXER_DETRIGGERSTATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xADCC16A2": {
-      "name": "_DYNAMICMIXER_2",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    }
-  },
-  "RIDING": {
-    "0x00AF2CB0": {
-      "name": "SET_MOST_RECENT_MOUNT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x708E450F": {
-      "name": "GET_MOST_RECENT_MOUNT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x668E55C3": {
-      "name": "GET_MOST_RECENT_RIDER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xDB0D0478": {
-      "name": "IS_ACTOR_HORSE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x1F739295": {
-      "name": "IS_ACTOR_MULE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xA6BBE769": {
-      "name": "IS_ACTOR_RIDING",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0xF270EAC1": {
-      "name": "IS_ACTOR_RIDING_AND_IN_SADDLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xA3AB3708": {
-      "name": "IS_ACTOR_MOUNTED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x88A283E5": {
-      "name": "GET_RIDER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xDD31EC4E": {
-      "name": "GET_MOUNT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "Actor"
-    },
-    "0xDC6DEE92": {
-      "name": "SET_MOUNTS_AS_PASSENGER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xC28242F4": {
-      "name": "ACTOR_MOUNT_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Actor",
-          "name": "actor2"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x374D047A": {
-      "name": "REMOVE_HORSE_ACCESSORY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x75D4E33F": {
-      "name": "DOES_HORSE_HAVE_ACCESSORY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x6C939AA7": {
-      "name": "ACCESSORIZE_HORSE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x6B6E05A8": {
-      "name": "HORSE_ENABLE_AUTO_JUMP_FOR_AI_RIDERS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xCA7CB126": {
-      "name": "HORSE_AUTO_JUMP_ENABLED_FOR_AI_RIDERS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x28FCBDF2": {
-      "name": "HORSE_ADD_REPULSION_EXCLUSION_VOLUME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x5DE07F18": {
-      "name": "HORSE_REMOVE_REPULSION_EXCLUSION_VOLUME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xF3976D70": {
-      "name": "HORSE_SET_CURR_FRESHNESS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xB8665D8A": {
-      "name": "HORSE_GET_CURR_FRESHNESS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x8754817D": {
-      "name": "HORSE_LOCK_FRESHNESS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x6AFA044B": {
-      "name": "HORSE_UNLOCK_FRESHNESS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xB731EB45": {
-      "name": "HORSE_SET_INFINITE_FRESHNESS_CHEAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "BOOL",
-          "name": "toggle"
-        }
-      ],
-      "return_type": "void"
-    }
-  },
-  "NAVMESH": {
-    "0x8A0D3339": {
-      "name": "STREAMING_IS_MOVABLE_NAV_MESH_RESIDENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x63334F63": {
-      "name": "STREAMING_REQUEST_MOVABLE_NAV_MESH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xC329E1DB": {
-      "name": "STREAMING_UNREQUEST_MOVABLE_NAV_MESH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xECEE9E20": {
-      "name": "SET_ACTOR_MOVABLE_NAV_MESH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    }
-  },
-  "MOVIE": {
-    "0x92028B49": {
-      "name": "WORLD_MOVIE_PLAYER",
-      "comment": "Not in PS4/Switch/PC",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7614AEBA": {
-      "name": "_0x7614AEBA",
-      "comment": "PS4/Switch/PC only",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x69FC319E": {
-      "name": "_0x69FC319E",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xD036DF91": {
-      "name": "_0xD036DF91",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    }
-  },
-  "MOTIVE": {
-    "0x1BED8493": {
-      "name": "SET_MOTIVE_BY_ENUM",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    }
-  },
-  "AMBIENCE": {
-    "0x2A3B1045": {
-      "name": "AMBIENCE_AUDIO_ENTITY_UPDATE_TERRITORY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x27A96719": {
-      "name": "AMBIENCE_AUDIO_ENTITY_UPDATE_LOCATION",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "p0"
-        },
-        {
-          "type": "const char*",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC0556FB8": {
-      "name": "AMBIENCE_AUDIO_VALIDATE_REGION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    }
-  },
-  "NAVQUERY": {
-    "0xE2F41226": {
-      "name": "CREATE_NAV_QUERY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xE96D01E5": {
-      "name": "NAV_QUERY_IS_DONE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5A511344": {
-      "name": "NAV_QUERY_CAN_PATH_TO_POINT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xAFA35FFA": {
-      "name": "NAV_QUERY_RECEIVE_CAN_PATH_TO_POINT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x07A777D7": {
-      "name": "NAV_QUERY_START_CAN_PATH_TO_POINT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x50290FB3": {
-      "name": "NAV_QUERY_STOP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    }
-  },
-  "NET": {
-    "0x6BCFE549": {
-      "name": "NET_SET_TUNING_PARAM",
+  "OBJECT2": {
+    "0x7080E24A": {
+      "name": "_0x7080E24A",
       "comment": "",
       "params": [
         {
@@ -34795,145 +39756,10 @@
           "name": "p1"
         }
       ],
-      "return_type": "int*"
-    },
-    "0x50E637D7": {
-      "name": "_0x50E637D7",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x48275716": {
-      "name": "NET_LOG",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xD164026F": {
-      "name": "NET_DUMP_STATE",
-      "comment": "",
-      "params": [],
       "return_type": "int"
     },
-    "0x9180FF1C": {
-      "name": "NET_ENABLE_MULTIPLAYER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x84B0B5D6": {
-      "name": "NET_IS_MANAGER_INITIALIZED",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x8CA54980": {
-      "name": "NET_IS_IN_SESSION",
-      "comment": "",
-      "params": [],
-      "return_type": "BOOL"
-    },
-    "0x5FF2BAE0": {
-      "name": "NET_IS_ONLINE_AVAILABLE",
-      "comment": "",
-      "params": [],
-      "return_type": "BOOL"
-    },
-    "0x7AB722D8": {
-      "name": "NET_IS_CONNECTED_FOR_PLAY",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xBC4B6B74": {
-      "name": "NET_GET_PLAYMODE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x18EC9CF0": {
-      "name": "NET_APPLY_PROTOCOL_MASK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x17D14553": {
-      "name": "NET_SET_SOCIAL_CLUB_URLS",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "result"
-        },
-        {
-          "type": "const char*",
-          "name": "p1"
-        },
-        {
-          "type": "Any*",
-          "name": "p2"
-        }
-      ],
-      "return_type": "const char*"
-    },
-    "0xCDAC0F0E": {
-      "name": "NET_IS_SESSION_HOST",
-      "comment": "",
-      "params": [],
-      "return_type": "BOOL"
-    },
-    "0xFF65A07C": {
-      "name": "NET_IS_SESSION_CLIENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x75DD203B": {
-      "name": "NET_GET_MAC_ADDRESS32",
+    "0x1D7845B7": {
+      "name": "_0x1D7845B7",
       "comment": "",
       "params": [
         {
@@ -34942,2416 +39768,6 @@
         }
       ],
       "return_type": "void"
-    },
-    "0x31700C0A": {
-      "name": "NET_GET_NAT_TYPE",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x0678A865": {
-      "name": "NET_IS_BUSY",
-      "comment": "",
-      "params": [],
-      "return_type": "BOOL"
-    },
-    "0xFF8DA25D": {
-      "name": "NET_GET_NET_TIME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xB829A92D": {
-      "name": "NET_ENABLE_KICKING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x71D989BD": {
-      "name": "NET_IS_LOCAL_GAMER_ONLINE",
-      "comment": "",
-      "params": [],
-      "return_type": "BOOL"
-    },
-    "0x95CDCE7A": {
-      "name": "NET_GET_LOCAL_GAMER_NAME",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0xAD85A378": {
-      "name": "NET_APPLY_RELEVANCY_OVERRIDE",
-      "comment": "",
-      "params": [],
-      "return_type": "int*"
-    },
-    "0x72B03551": {
-      "name": "NET_CLEAR_RELEVANCY_OVERRIDE",
-      "comment": "",
-      "params": [],
-      "return_type": "int*"
-    },
-    "0x860FCDBD": {
-      "name": "GET_SLOT_FOR_HOST",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x0F99A8BC": {
-      "name": "GET_NUM_PLAYERS",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x84D6F8A7": {
-      "name": "NET_START_NEW_SCRIPT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5E985228": {
-      "name": "NET_SCRIPTMSG_SEND",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "channelId"
-        },
-        {
-          "type": "int",
-          "name": "headerSize"
-        },
-        {
-          "type": "int*",
-          "name": "buffer"
-        },
-        {
-          "type": "int",
-          "name": "count"
-        },
-        {
-          "type": "bool",
-          "name": "pushToQueue"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xE2163ECC": {
-      "name": "NET_SCRIPTMSG_ISPENDING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xB13DD691": {
-      "name": "NET_SCRIPTMSG_GETNEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9253CC79": {
-      "name": "NET_SCRIPTMSG_REGISTER_HANDLER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x4957E482": {
-      "name": "NET_SCRIPTMSG_QUERY_HANDLER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xBEDD194D": {
-      "name": "REGISTER_HOST_BROADCAST_VARIABLES",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xF1732769": {
-      "name": "REGISTER_CLIENT_BROADCAST_VARIABLES",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x2707F082": {
-      "name": "UNREGISTER_HOST_BROADCAST_VARIABLES",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x0130DB5D": {
-      "name": "UNREGISTER_CLIENT_BROADCAST_VARIABLES",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0xF81E2097": {
-      "name": "_IS_CLIENT_DATA_VALID_FOR_SLOT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x64C2DD40": {
-      "name": "_IS_CLIENT_DATA_VALID_FOR_SLOT_2",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xA80C6DE6": {
-      "name": "_0xA80C6DE6",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xD12C55A5": {
-      "name": "NET_IS_OBJECT_LOCAL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x68EC589D": {
-      "name": "NET_REQUEST_OBJECT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x47C5E353": {
-      "name": "_0x47C5E353",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x3932B786": {
-      "name": "_0x3932B786",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "result"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x138F38AC": {
-      "name": "NET_OBJECT_GET_REPLICATION_MODE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x3E509DF1": {
-      "name": "NET_OBJECT_SET_REPLICATION_MODE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8C7E41E2": {
-      "name": "NET_OBJECT_LOCK_OWNERSHIP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x1306549E": {
-      "name": "_0x1306549E",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5C4CAE3A": {
-      "name": "_0x5C4CAE3A",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int*"
-    },
-    "0x579C2014": {
-      "name": "_0x579C2014",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7837890B": {
-      "name": "_NET_SET_EQUIP_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xA6D794FE": {
-      "name": "_0xA6D794FE",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "result"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x1C147E14": {
-      "name": "_0x1C147E14",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "result"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xCA6231C1": {
-      "name": "_0xCA6231C1",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC09B114B": {
-      "name": "_NET_ACTOR_OBJECT_ID",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "result"
-        },
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7284A71B": {
-      "name": "_NET_ACTOR_OBJECT_ID_2",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "result"
-        },
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7AB65B0C": {
-      "name": "NET_GET_SESSION_GAMER_COUNT",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xCAA24B1A": {
-      "name": "AWARD_ACHIEVEMENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x136A5BE9": {
-      "name": "HAS_ACHIEVEMENT_BEEN_PASSED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xC792A9E0": {
-      "name": "ARE_ACHIEVEMENTS_READY",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xDD33E221": {
-      "name": "AWARD_AVATAR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xC4F9DA6E": {
-      "name": "NET_GET_POSSE_COUNT",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x1CAD6D29": {
-      "name": "NET_IS_POSSE_LEADER",
-      "comment": "",
-      "params": [],
-      "return_type": "BOOL"
-    },
-    "0x0D914C89": {
-      "name": "NET_GET_POSSE_LEADER_SLOT",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xFC52BD15": {
-      "name": "NET_GET_GAMER_POSSE_LEADER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xB6006EA9": {
-      "name": "NET_GET_GAMER_POSSE_SIZE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x98A5CDC5": {
-      "name": "NET_POSSE_REMOVE_GAMER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x106CE441": {
-      "name": "_0x106CE441",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x6A7B9FAD": {
-      "name": "_0x6A7B9FAD",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x2037A74F": {
-      "name": "NET_RUN_SEARCH_BOT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x89D8FC30": {
-      "name": "NET_GET_NUMBER_OF_SESSIONS",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x2010ABE6": {
-      "name": "NET_IS_SEARCHBOT_BUSY",
-      "comment": "",
-      "params": [],
-      "return_type": "BOOL"
-    },
-    "0xF6E40FF3": {
-      "name": "_0xF6E40FF3",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC0849D70": {
-      "name": "_0xC0849D70",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x8DF05A4F": {
-      "name": "_0x8DF05A4F",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x4AE5DBB2": {
-      "name": "NET_SESSION_LEAVE_SESSION",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x80B20614": {
-      "name": "NET_IS_FACTION_SAFE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x86FF3A9B": {
-      "name": "NET_SESSION_START_GAMEPLAY",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x81FD9851": {
-      "name": "NET_SESSION_END_GAMEPLAY",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x3A5C56E3": {
-      "name": "NET_SESSION_SET_INVITABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xFA0E1F8B": {
-      "name": "_0xFA0E1F8B",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xCC7D0431": {
-      "name": "_0xCC7D0431",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xDC88B308": {
-      "name": "NET_SESSION_IS_GAMEPLAY_STARTED",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xD923CD1B": {
-      "name": "_0xD923CD1B",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7540959C": {
-      "name": "_NET_REQUEST_BECOME_GAME_HOST",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xEE3B79EE": {
-      "name": "NET_SET_THIS_SCRIPT_IS_NET_SCRIPT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4238C471": {
-      "name": "NET_UNREGISTER_AS_NET_SCRIPT",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x667DA125": {
-      "name": "NET_GET_SCRIPT_STATUS",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x110A9B2F": {
-      "name": "NET_IS_PLAYER_PARTICIPANT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Player",
-          "name": "player"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x6D403720": {
-      "name": "NET_IS_HOST_OF_THIS_SCRIPT",
-      "comment": "",
-      "params": [],
-      "return_type": "BOOL"
-    },
-    "0x9272C3BA": {
-      "name": "NET_GET_HOST_OF_THIS_SCRIPT",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x408E28E2": {
-      "name": "NET_ALLOW_PLAYERS_TO_JOIN",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC0FC4B57": {
-      "name": "NET_IS_SCRIPT_REGISTERED_AS_NET_SCRIPT",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xD9965A9A": {
-      "name": "NET_SCRIPT_GET_NUM_PARTICIPANTS",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x7BDCBD45": {
-      "name": "SET_RICH_PRESENCE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x50C18480": {
-      "name": "_0x50C18480",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE5645CB3": {
-      "name": "_0xE5645CB3",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x79AFAB1F": {
-      "name": "_0x79AFAB1F",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        },
-        {
-          "type": "Any",
-          "name": "p9"
-        },
-        {
-          "type": "Any",
-          "name": "p10"
-        },
-        {
-          "type": "Any",
-          "name": "p11"
-        },
-        {
-          "type": "Any",
-          "name": "p12"
-        },
-        {
-          "type": "Any",
-          "name": "p13"
-        },
-        {
-          "type": "Any",
-          "name": "p14"
-        },
-        {
-          "type": "Any",
-          "name": "p15"
-        },
-        {
-          "type": "Any",
-          "name": "p16"
-        },
-        {
-          "type": "Any",
-          "name": "p17"
-        },
-        {
-          "type": "Any",
-          "name": "p18"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x581CAC89": {
-      "name": "_0x581CAC89",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xA174152C": {
-      "name": "_0xA174152C",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x0183A3F0": {
-      "name": "_0x0183A3F0",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x63034F52": {
-      "name": "_0x63034F52",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE9EAC45C": {
-      "name": "_0xE9EAC45C",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xBDF22FCA": {
-      "name": "IS_SESSION_CURRENTLY_JOINED_SESSION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9EA132A3": {
-      "name": "_0x9EA132A3",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xCB0BCAE2": {
-      "name": "NET_SESSION_SET_GAME_MODE_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7A99E7DE": {
-      "name": "NET_VOICE_BROADCAST_ENABLE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x1D5E39A0": {
-      "name": "NET_VOICE_BROADCAST_DISABLE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xEF6BF96E": {
-      "name": "NET_ARE_UNLOCKS_READY",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xC8B680B3": {
-      "name": "NET_IS_UNLOCKED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xBE0E275F": {
-      "name": "NET_GET_OVERLOAD_STATE_FOR_SLOT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xCB42389E": {
-      "name": "NET_GET_AREA_OVERLOAD_STATE_FOR_SLOT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x842ADE0A": {
-      "name": "_0x842ADE0A",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xB7856424": {
-      "name": "NET_SET_SYNC_PRIORITY_LIMITS",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xF2FA1DE8": {
-      "name": "UPDATE_PROFILE_STAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xCF674E31": {
-      "name": "UPDATE_STRING_PROFILE_STAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x97F15B69": {
-      "name": "_AH_LAG_HACK_KILL_PROTECTION_ENABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xCA0739A8": {
-      "name": "_AH_LAG_HACK_MOVE_PROTECTION_ENABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x49BC0219": {
-      "name": "NET_BROADCAST_EXPLODE_TARGET_EVENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xD6780B56": {
-      "name": "DO_FILE_CRC",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9A5841E5": {
-      "name": "FLAG_FILE_CRC_MISMATCH",
-      "comment": "",
-      "params": [],
-      "return_type": "int*"
-    },
-    "0x489A2B93": {
-      "name": "NET_SET_UNLOCK",
-      "comment": "PS4/Switch/PC only",
-      "params": [],
-      "return_type": "int*"
-    }
-  },
-  "NET2": {
-    "0x55C5BB93": {
-      "name": "_0x55C5BB93",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xFAD5A270": {
-      "name": "_0xFAD5A270",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x4A721118": {
-      "name": "GAME_INSTANCE_ITERATOR_START",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x4500B98A": {
-      "name": "GAME_INSTANCE_ITERATOR_NEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x85049505": {
-      "name": "_0x85049505",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5C51D43C": {
-      "name": "ADD_PLAYLIST_TO_DB",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x0E2C4B68": {
-      "name": "GET_PLAYLIST_FROM_DB",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xB514ECA7": {
-      "name": "GET_PLAYLIST_FROM_DB_BY_NAME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    }
-  },
-  "NET_STATS": {
-    "0x12304873": {
-      "name": "NET_UPDATE_LEADERBOARD",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4D0C8AA4": {
-      "name": "_0x4D0C8AA4",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x89277EA3": {
-      "name": "_0x89277EA3",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x2B8F86ED": {
-      "name": "NET_CREATE_FRIEND_SCORE_READER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x88249424": {
-      "name": "NET_REPORT_FRIEND_SCORES",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x87A3A38D": {
-      "name": "_0x87A3A38D",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xD7572C68": {
-      "name": "_0xD7572C68",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x76F09F04": {
-      "name": "_0x76F09F04",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xA684E813": {
-      "name": "_0xA684E813",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xE5C5CE63": {
-      "name": "_0xE5C5CE63",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x4F652A00": {
-      "name": "_0x4F652A00",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xFC564903": {
-      "name": "_0xFC564903",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x7154D15B": {
-      "name": "_0x7154D15B",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x86BC0A55": {
-      "name": "_0x86BC0A55",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xEB4A6D85": {
-      "name": "_0xEB4A6D85",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x5FD52711": {
-      "name": "_0x5FD52711",
-      "comment": "",
-      "params": [],
-      "return_type": "BOOL"
-    },
-    "0xD0808C42": {
-      "name": "_0xD0808C42",
-      "comment": "",
-      "params": [],
-      "return_type": "BOOL"
-    },
-    "0x097BB984": {
-      "name": "_0x097BB984",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xEA7ADF42": {
-      "name": "_0xEA7ADF42",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x3A8C77AD": {
-      "name": "_0x3A8C77AD",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE89C6E4F": {
-      "name": "_0xE89C6E4F",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x0791F35A": {
-      "name": "_0x0791F35A",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x49C2B05F": {
-      "name": "_0x49C2B05F",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC813DBEF": {
-      "name": "_0xC813DBEF",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xE6B4F505": {
-      "name": "_0xE6B4F505",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x70AF0351": {
-      "name": "_0x70AF0351",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x293C3288": {
-      "name": "_0x293C3288",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xA7F231B0": {
-      "name": "_0xA7F231B0",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x984749B4": {
-      "name": "_0x984749B4",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    }
-  },
-  "NET_UI": {
-    "0x8808546E": {
-      "name": "NET_GET_AND_CLEAR_GAME_MODE_REQUEST",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x1A47001B": {
-      "name": "NET_GET_AND_CLEAR_PLAYLIST_REQUEST",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x0FF6B8F4": {
-      "name": "NET_GET_AND_CLEAR_QUIT_GAME_REQUEST",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x81F24788": {
-      "name": "NET_GET_FREE_ROAM_MODE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x41921C98": {
-      "name": "NET_SET_FREE_ROAM_MODE",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "mode"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE822010A": {
-      "name": "NET_REGISTER_GAME_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xA9459BB6": {
-      "name": "NET_REGISTER_PLAYLIST_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x9D9784B8": {
-      "name": "NET_SET_PLAYLIST_LOCKED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x03962973": {
-      "name": "_0x03962973",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x8E0D7219": {
-      "name": "NET_AUTHENTICATE_GAMER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC00C8C94": {
-      "name": "_0xC00C8C94",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9BC05C90": {
-      "name": "_0x9BC05C90",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x97931B87": {
-      "name": "NET_GET_GAMER_RGB_COLOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xFE83A4FE": {
-      "name": "_0xFE83A4FE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8DEC3E03": {
-      "name": "_0x8DEC3E03",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xBECB3EEC": {
-      "name": "NET_PLAYER_BARKER_RESET",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x75F27D60": {
-      "name": "NET_GET_USING_SPHERE_CURVES",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xA64A451E": {
-      "name": "NET_PLAYER_SHOW_CONTEXT_MENU",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x67031EDA": {
-      "name": "NET_PLAYER_LIST_RESET",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xFD355ED1": {
-      "name": "NET_PLAYER_LIST_ADD_ITEM",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "text"
-        },
-        {
-          "type": "int",
-          "name": "rowIndex"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x805AC16A": {
-      "name": "NET_PLAYER_LIST_ADD_GAMER_SLOT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x0AAE9E6B": {
-      "name": "NET_PLAYER_LIST_SET_HIGHLIGHT",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "highlightIndex"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x20B684AB": {
-      "name": "NET_PLAYER_LIST_SET_TOP_TEAM",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x84CD0651": {
-      "name": "NET_PLAYER_LIST_SET_TEAM_SCORE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xA56B459C": {
-      "name": "NET_PLAYER_LIST_SET_TEAM_SORT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x0547A660": {
-      "name": "NET_PLAYER_LIST_SET_TITLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "gxtName"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xD6111569": {
-      "name": "NET_PLAYER_LIST_SET_TEMPLATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "menuTemplate"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xFA382FCB": {
-      "name": "NET_PLAYER_LIST_SET_HEADER",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "columnIndex"
-        },
-        {
-          "type": "const char*",
-          "name": "entry"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xCF065186": {
-      "name": "NET_PLAYER_LIST_SET_DESCRIPTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "str"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xBE7965C8": {
-      "name": "NET_PLAYER_LIST_TIMER_SET",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xD4C7E0D5": {
-      "name": "_0xD4C7E0D5",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x98FC68AF": {
-      "name": "NET_PLAYER_LIST_SET_CURRENT_ITEM",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x95A543E2": {
-      "name": "NET_PLAYER_LIST_SET_CURRENT_ITEM_BY_SLOT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC673362C": {
-      "name": "NET_PLAYER_LIST_SET_CURRENT_ITEM_MSCORE_STRING",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "columnIndex"
-        },
-        {
-          "type": "const char*",
-          "name": "text"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xEC6F465F": {
-      "name": "NET_PLAYER_LIST_SET_CURRENT_ITEM_MSCORE_INT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x794F5C21": {
-      "name": "NET_PLAYER_LIST_SET_CURRENT_ITEM_TEAM",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "groupColor"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xBD42097A": {
-      "name": "NET_PLAYER_LIST_SET_CURRENT_ITEM_PRIORITY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC09ACD5C": {
-      "name": "NET_PLAYER_LIST_SET_CURRENT_ITEM_DEAD",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC73DAD2B": {
-      "name": "NET_TICKER_REPORTF",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "text1"
-        },
-        {
-          "type": "const char*",
-          "name": "text2"
-        },
-        {
-          "type": "const char*",
-          "name": "text3"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8A1D83F2": {
-      "name": "NET_TICKER_CLEAR",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xA6403262": {
-      "name": "_0xA6403262",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x27D40FD1": {
-      "name": "NET_SCOREGRAPH_SETUP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xA3AE09EF": {
-      "name": "NET_SCOREGRAPH_CLEAR_MARKERS",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x746897AB": {
-      "name": "NET_SCOREGRAPH_ADD_PLAYER_SCORE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xB4C867BD": {
-      "name": "NET_SCOREGRAPH_ADD_PLAYER_LABEL",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x12558DBD": {
-      "name": "NET_SCOREGRAPH_ADD_TEAM_SCORE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x134AAF17": {
-      "name": "NET_SCOREGRAPH_ADD_TEAM_LABEL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    }
-  },
-  "PLAYSTATS": {
-    "0x2547029C": {
-      "name": "_0x2547029C",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x6F6D942B": {
-      "name": "_0x6F6D942B",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x713B1D7F": {
-      "name": "_0x713B1D7F",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x9C80A3A4": {
-      "name": "_START",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x27A00456": {
-      "name": "_MP_DEED_START",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x120E6123": {
-      "name": "_MP_DEED_COMPLETE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x4585821E": {
-      "name": "_MP_DEED_COMPLETE_EX",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x46C39437": {
-      "name": "_MP_COOP_COMPLETE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        }
-      ],
-      "return_type": "Any"
     }
   },
   "PATH": {
@@ -37531,6 +39947,288 @@
       "return_type": "void"
     }
   },
+  "PC": {
+    "0x8CF09BD7": {
+      "name": "_0x8CF09BD7",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xBAE0A3F8": {
+      "name": "_0xBAE0A3F8",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x9F832205": {
+      "name": "_0x9F832205",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xF413FDB2": {
+      "name": "_0xF413FDB2",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x63D3AAFC": {
+      "name": "_0x63D3AAFC",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x3B93B981": {
+      "name": "_0x3B93B981",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x854ACCFE": {
+      "name": "SET_HORSE_BREAK_INTRO",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xEB0F9F0C": {
+      "name": "_0xEB0F9F0C",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xFD198D8B": {
+      "name": "SET_SAVING_GAME",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xA62D75BA": {
+      "name": "SET_SAVING_GAME_ZOMBIE",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x7C730896": {
+      "name": "_0x7C730896",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x02859CE6": {
+      "name": "_0x02859CE6",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x5B47E49A": {
+      "name": "_0x5B47E49A",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x97609434": {
+      "name": "_0x97609434",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x920DB21": {
+      "name": "_0x0920DB21",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x9CED1C7E": {
+      "name": "_0x9CED1C7E",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xD9DDA7E2": {
+      "name": "_0xD9DDA7E2",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x14664FF4": {
+      "name": "SET_USING_BINOCULARS",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xB0E60B63": {
+      "name": "_0xB0E60B63",
+      "comment": "PC only",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    }
+  },
+  "PED": {
+    "0xD02757C1": {
+      "name": "CAN_ACTOR_ENUM_PLAY_SPEECH_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x886E06C2": {
+      "name": "REGISTER_ACTOR_SPEECH_CONTEXT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "const char*",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        }
+      ],
+      "return_type": "int*"
+    },
+    "0xB6839756": {
+      "name": "FINISH_REGISTERING_ACTOR_SPEECH_CONTEXTS",
+      "comment": "",
+      "params": [],
+      "return_type": "int*"
+    },
+    "0xCB139D15": {
+      "name": "REGISTER_NUM_SPEECH_CONTEXTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "const char*"
+    },
+    "0xF07F5E41": {
+      "name": "REGISTER_NUM_CONTEXT_TYPES",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    }
+  },
   "PERSCHAR": {
     "0x2CA16327": {
       "name": "ACTIVATE_ACTOR_FOR_PERS_CHAR",
@@ -37683,6 +40381,189 @@
         }
       ],
       "return_type": "void"
+    }
+  },
+  "PHYSICS": {
+    "0x17B69196": {
+      "name": "GET_PHYSINST_VELOCITY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xAFB1DFA2": {
+      "name": "IS_PHYSINST_ACTIVE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x38636EBF": {
+      "name": "SET_PHYSINST_COLLIDES_AGAINST_INACTIVE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x2C0AF634": {
+      "name": "SET_PHYSINST_FROZEN",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x789AA2B2": {
+      "name": "IS_PHYSINST_FROZEN",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xEBD9DFE6": {
+      "name": "SET_PHYSINST_HIDE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x445990D8": {
+      "name": "IS_PHYSINST_HIDE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xB5F9F4CF": {
+      "name": "BREAK_OFF_ABOVE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0BA5E579": {
+      "name": "GET_LOCATOR_OFFSETS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xFD759593": {
+      "name": "_0xFD759593",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x87A2C1D5": {
+      "name": "SET_GLOBAL_DISABLE_SPU_COLLIDER_UPDATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x374DE883": {
+      "name": "SET_GLOBAL_AGGRESSIVE_CORPSE_RECYCLING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x89B45C7D": {
+      "name": "LIQUID_TEST_SET_VELOCITY_SCALE",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x4C02E1E5": {
+      "name": "CLEAN_CACHE_ENTRIES",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
     }
   },
   "PHYSINST": {
@@ -38079,9 +40960,9 @@
       "return_type": "int"
     }
   },
-  "MISC": {
-    "0x11069324": {
-      "name": "CREATE_OBJECT_LOCATOR",
+  "PLAYERNAMES": {
+    "0x77D6ABF5": {
+      "name": "NET_GAMER_SET_ACTOR_OVERRIDE",
       "comment": "",
       "params": [
         {
@@ -38093,10 +40974,69 @@
           "name": "p1"
         }
       ],
+      "return_type": "void"
+    },
+    "0xE79F6CD4": {
+      "name": "NET_GAMER_SET_TEAM",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xFD91BE0D": {
+      "name": "_0xFD91BE0D",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
       "return_type": "int"
     },
-    "0x0B24362F": {
-      "name": "_0x0B24362F",
+    "0xE2E6C722": {
+      "name": "IN_SELECTED_PEDPATH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xCE8F6304": {
+      "name": "_0xCE8F6304",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xAB32D5D9": {
+      "name": "_0xAB32D5D9",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7BD7A465": {
+      "name": "NET_GAMER_SET_TITLE",
       "comment": "",
       "params": [
         {
@@ -38110,36 +41050,12 @@
         {
           "type": "Any",
           "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        },
-        {
-          "type": "float",
-          "name": "p4"
-        },
-        {
-          "type": "float",
-          "name": "p5"
-        },
-        {
-          "type": "float",
-          "name": "p6"
-        },
-        {
-          "type": "float",
-          "name": "p7"
-        },
-        {
-          "type": "float",
-          "name": "p8"
         }
       ],
-      "return_type": "int"
+      "return_type": "void"
     },
-    "0xE25F407D": {
-      "name": "_0xE25F407D",
+    "0x2357CA74": {
+      "name": "_0x2357CA74",
       "comment": "",
       "params": [
         {
@@ -38147,81 +41063,18 @@
           "name": "p0"
         },
         {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
           "type": "float",
-          "name": "p3"
-        },
-        {
-          "type": "float",
-          "name": "p4"
-        },
-        {
-          "type": "float",
-          "name": "p5"
-        },
-        {
-          "type": "float",
-          "name": "p6"
-        },
-        {
-          "type": "float",
-          "name": "p7"
-        },
-        {
-          "type": "float",
-          "name": "p8"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xEB33480A": {
-      "name": "_0xEB33480A",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
           "name": "p1"
         },
         {
           "type": "float",
           "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        },
-        {
-          "type": "float",
-          "name": "p4"
-        },
-        {
-          "type": "float",
-          "name": "p5"
-        },
-        {
-          "type": "float",
-          "name": "p6"
-        },
-        {
-          "type": "float",
-          "name": "p7"
         }
       ],
       "return_type": "int"
     },
-    "0x88F7432C": {
-      "name": "_0x88F7432C",
+    "0x160E79C6": {
+      "name": "_0x160E79C6",
       "comment": "",
       "params": [
         {
@@ -38235,8 +41088,23 @@
       ],
       "return_type": "int"
     },
-    "0x04507DBC": {
-      "name": "_0x04507DBC",
+    "0xB5DDEF68": {
+      "name": "_0xB5DDEF68",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x34960D06": {
+      "name": "_0x34960D06",
       "comment": "",
       "params": [
         {
@@ -38248,238 +41116,214 @@
           "name": "p1"
         }
       ],
+      "return_type": "int"
+    },
+    "0xE783219A": {
+      "name": "_0xE783219A",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x1958F478": {
+      "name": "END_SCRIPTED_REQUEST",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x2FB85996": {
+      "name": "_0x2FB85996",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xF34B8448": {
+      "name": "_0xF34B8448",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x796E66E7": {
+      "name": "_0x796E66E7",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x650A7440": {
+      "name": "_GROUP_COLOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xA0A5FF80": {
+      "name": "NET_GAMER_SET_ICON_STEALTH_OVERRIDE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x2634F265": {
+      "name": "NET_GAMER_SET_BLIP_STEALTH_OVERRIDE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x4A2E7533": {
+      "name": "IS_HORSES_RELATIVE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x08D84437": {
+      "name": "_0x08D84437",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x784F04DD": {
+      "name": "_0x784F04DD",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x3DD6E36A": {
+      "name": "_0x3DD6E36A",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE5FE0A6A": {
+      "name": "_0xE5FE0A6A",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x25F8C46A": {
+      "name": "_0x25F8C46A",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x3248D20E": {
+      "name": "_0x3248D20E",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x9DDB29B1": {
+      "name": "NET_POSSE_GET_LEADER_WAYPOINT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x24A1B923": {
+      "name": "NET_POSSE_IS_LEADER_WAYPOINT_VALID",
+      "comment": "",
+      "params": [],
       "return_type": "int"
     }
   },
-  "ACTOR": {
-    "0x2D54B916": {
-      "name": "TELEPORT_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "float",
-          "name": "x"
-        },
-        {
-          "type": "float",
-          "name": "y"
-        },
-        {
-          "type": "float",
-          "name": "z"
-        },
-        {
-          "type": "BOOL",
-          "name": "p4"
-        },
-        {
-          "type": "BOOL",
-          "name": "p5"
-        },
-        {
-          "type": "BOOL",
-          "name": "p6"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE4DE507C": {
-      "name": "TELEPORT_ACTOR_WITH_HEADING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "float",
-          "name": "x"
-        },
-        {
-          "type": "float",
-          "name": "y"
-        },
-        {
-          "type": "float",
-          "name": "z"
-        },
-        {
-          "type": "float",
-          "name": "heading"
-        },
-        {
-          "type": "BOOL",
-          "name": "p5"
-        },
-        {
-          "type": "BOOL",
-          "name": "p6"
-        },
-        {
-          "type": "BOOL",
-          "name": "p7"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x6B3A39A9": {
-      "name": "GET_MAX_SPEED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x99BD9D6F": {
-      "name": "GET_POSITION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "float*",
-          "name": "x"
-        },
-        {
-          "type": "float*",
-          "name": "y"
-        },
-        {
-          "type": "float*",
-          "name": "z"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x42DE39F0": {
-      "name": "GET_HEADING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0x294A5549": {
-      "name": "GET_ACTOR_AXIS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xECE8520B": {
-      "name": "SET_ACTOR_HEADING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "float",
-          "name": "heading"
-        },
-        {
-          "type": "BOOL",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xCDC686B2": {
-      "name": "SET_ACTOR_ONE_SHOT_DEATH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "BOOL",
-          "name": "toggle"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0912622D": {
-      "name": "GET_ACTOR_ONE_SHOT_DEATH_STATUS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x758F993A": {
-      "name": "GET_PHYSINST_FROM_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "int*",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x1AA3A0C0": {
-      "name": "CAN_ACTOR_HOGTIE_TARGET",
+  "PLAYSTATS": {
+    "0x2547029C": {
+      "name": "_0x2547029C",
       "comment": "",
       "params": [
         {
@@ -38493,363 +41337,8 @@
       ],
       "return_type": "int"
     },
-    "0xB27E91E7": {
-      "name": "IS_ACTOR_PLAYER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x6542CF26": {
-      "name": "IS_ACTOR_LOCAL_PLAYER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xB114332D": {
-      "name": "_PUSH_NEG_ONE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x524F6981": {
-      "name": "_GET_ACTOR_CONTROLLER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xCF02D1D6": {
-      "name": "_0xCF02D1D6",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x8F82B7D4": {
-      "name": "_0x8F82B7D4",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC733BC9A": {
-      "name": "SET_ENABLE_NAV_STICK_INPUT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xD17AFCD8": {
-      "name": "SET_PLAYER_CONTROL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "BOOL",
-          "name": "toggle"
-        },
-        {
-          "type": "int",
-          "name": "possiblyFlags"
-        },
-        {
-          "type": "BOOL",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xBEEDDD54": {
-      "name": "SET_PLAYER_ENABLE_MOUNT_USE_CONTEXTS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "BOOL",
-          "name": "toggle"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xEA08A934": {
-      "name": "SET_PLAYER_ALLOW_PICKUP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xAC1285A3": {
-      "name": "SET_PLAYER_MELEE_MODE_SELECTED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "int",
-          "name": "mode"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0959C27A": {
-      "name": "SET_PLAYER_DISABLE_TARGETING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x9613C2D0": {
-      "name": "_0x9613C2D0",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x6576AD43": {
-      "name": "IS_PLAYER_IN_COMBAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x48B7C279": {
-      "name": "IS_PLAYER_IN_COMBAT_WITHIN",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xCE7CE46D": {
-      "name": "SET_RETICLE_DRAW_DISABLED_BY_SCRIPT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x4590CE00": {
-      "name": "SET_PLAYER_CONTROL_RUMBLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Player",
-          "name": "player"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xB3BE2F95": {
-      "name": "RESET_RUMBLE",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x8421033D": {
-      "name": "GET_PLAYER_CONTROL_CONFIG",
-      "comment": "",
-      "params": [
-        {
-          "type": "Player",
-          "name": "player"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x01B84BCA": {
-      "name": "SET_PLAYER_CONTROL_CONFIG",
-      "comment": "",
-      "params": [
-        {
-          "type": "Player",
-          "name": "player"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x2E0EC2F2": {
-      "name": "PLAYER_RUMBLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4B0D6152": {
-      "name": "SET_PLAYER_CURRENT_NOTORIETY",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x4D918005": {
-      "name": "SET_PLAYER_CURRENT_HONOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x57595189": {
-      "name": "SET_PLAYER_COMBATMODE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Player",
-          "name": "player"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x86E193B8": {
-      "name": "GET_PLAYER_COMBATMODE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xAFFBBE78": {
-      "name": "SET_PLAYER_COMBATMODE_OVERRIDE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Player",
-          "name": "player"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x1184EC7B": {
-      "name": "SET_PLAYER_COMBATMODE_EXCLUSION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE1160B04": {
-      "name": "SET_PLAYER_VEHICLE_INPUT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Player",
-          "name": "player"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x900165CE": {
-      "name": "ADD_PLAYER_CONTROL_HORSE_FOLLOW",
+    "0x6F6D942B": {
+      "name": "_0x6F6D942B",
       "comment": "",
       "params": [
         {
@@ -38881,10 +41370,10 @@
           "name": "p6"
         }
       ],
-      "return_type": "int"
+      "return_type": "Any"
     },
-    "0xBFC8EF7C": {
-      "name": "REM_PLAYER_CONTROL_HORSE_FOLLOW",
+    "0x713B1D7F": {
+      "name": "_0x713B1D7F",
       "comment": "",
       "params": [
         {
@@ -38894,775 +41383,17 @@
         {
           "type": "Any",
           "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7C522386": {
-      "name": "CLEAR_PLAYER_CONTROL_HORSE_FOLLOW",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE44DCE87": {
-      "name": "IS_PLAYER_IN_HORSE_FOLLOW",
-      "comment": "",
-      "params": [
-        {
-          "type": "Player",
-          "name": "player"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xE8CFDD53": {
-      "name": "GET_PLAYER_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Player",
-          "name": "player"
-        }
-      ],
-      "return_type": "Actor"
-    },
-    "0x40EF1003": {
-      "name": "IS_LOCAL_PLAYER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x0ADC17E9": {
-      "name": "IS_LOCAL_PLAYER_VALID",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xD04480FE": {
-      "name": "IS_SLOT_VALID",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "slot"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xDB9B49D8": {
-      "name": "GET_SLOT_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
         }
       ],
       "return_type": "Any"
     },
-    "0xAABF3356": {
-      "name": "GET_ACTOR_SLOT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xAD68A22E": {
-      "name": "GET_LOCAL_SLOT",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x34CBABAE": {
-      "name": "GET_SLOT_NAME",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "slot"
-        }
-      ],
-      "return_type": "const char*"
-    },
-    "0x3241158C": {
-      "name": "GET_SLOT_POSITION",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "slot"
-        },
-        {
-          "type": "float*",
-          "name": "x"
-        },
-        {
-          "type": "float*",
-          "name": "y"
-        },
-        {
-          "type": "float*",
-          "name": "z"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x34A9866B": {
-      "name": "GET_SLOT_FACING",
+    "0x9C80A3A4": {
+      "name": "_START",
       "comment": "",
       "params": [
         {
           "type": "Any",
           "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x87DDCA96": {
-      "name": "IS_PLAYER_TARGETTING_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x622796D5": {
-      "name": "IS_PLAYER_TARGETTING_OBJECT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x6148423A": {
-      "name": "IS_PLAYER_DEADEYE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xB6A47C37": {
-      "name": "SET_PLAYER_DEADEYE_MODE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x1CFAF2EA": {
-      "name": "SET_FORCE_PLAYER_AIM_MODE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xD0E08B5E": {
-      "name": "SET_PLAYER_ENDLESS_READYMODE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xBC521A38": {
-      "name": "GET_PLAYER_ZOOM_STATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x724A2931": {
-      "name": "IS_PLAYER_USING_COVER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x45F2A70A": {
-      "name": "ATTACH_PLAYER_TO_COVER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0D77CC34": {
-      "name": "SIMULATE_PLAYER_INPUT_GAIT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xEAE75C6F": {
-      "name": "ACTOR_POP_NEXT_GAIT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x1ABFBFA3": {
-      "name": "ACTOR_SET_MAX_GAIT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xD39C4A9E": {
-      "name": "IS_ACTOR_USING_COVER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xEBBE1CAC": {
-      "name": "IS_ACTOR_USING_LEDGE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x50D8C840": {
-      "name": "SET_PLAYER_DEADEYE_POINTS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE2C4AEE7": {
-      "name": "ADD_PLAYER_DEADEYE_POINTS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x86B5C9E1": {
-      "name": "GET_PLAYER_DEADEYE_POINTS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x09716951": {
-      "name": "SET_DISABLE_DEADEYE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0486955B": {
-      "name": "SET_DEADEYE_POINT_MODIFIER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x526D45B7": {
-      "name": "SET_MAX_DEADEYE_POINTS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4E6E5E78": {
-      "name": "SET_DEADEYE_MULTILOCK_ENABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x5CD6E2C3": {
-      "name": "SET_DEADEYE_TARGETPAINT_ENABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xA671FF8E": {
-      "name": "SET_DEADEYE_INVULNERABILITY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0D583DAF": {
-      "name": "SET_DEADEYE_DAMAGE_SCALING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x863F0193": {
-      "name": "SET_DEADEYE_TIME_LIMIT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x0415EE4C": {
-      "name": "SET_DEADEYE_REGENERATION_RATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "float",
-          "name": "rate"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x151741A2": {
-      "name": "SET_DEADEYE_REGENERATION_RATE_MULTIPLIER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x5740CDC2": {
-      "name": "SET_DEADEYE_TIMESCALE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0C0BC04E": {
-      "name": "SET_INFINITE_DEADEYE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "BOOL",
-          "name": "toggle"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x7F454A92": {
-      "name": "_0x7F454A92",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0xFA8D2B69": {
-      "name": "SET_WAGON_TO_WAGON_JACK_ENABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x3BD4426B": {
-      "name": "SET_PLAYER_POSTURE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xC550644A": {
-      "name": "SET_ACTOR_ALLOW_DISMOUNT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE38EF526": {
-      "name": "SET_ACTOR_INVULNERABILITY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "BOOL",
-          "name": "toggle"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xDB39D992": {
-      "name": "GET_ACTOR_INVULNERABILITY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x2A575132": {
-      "name": "SET_TOUGH_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "BOOL",
-          "name": "toggle"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0D9A35F6": {
-      "name": "SET_ACTOR_UNKILLABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "BOOL",
-          "name": "toggle"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xB4CD475D": {
-      "name": "SET_ACTOR_PERMANENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x731F2C21": {
-      "name": "SET_ACTOR_PERMANENT_DEAD",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xED89D0E0": {
-      "name": "SET_ACTOR_FROZEN_AFTER_CORPSIFY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xF5B74E20": {
-      "name": "CLEAR_ACTOR_PROOF",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x9E7AE28B": {
-      "name": "CLEAR_ACTOR_PROOF_ALL",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "result"
         },
         {
           "type": "Any",
@@ -39681,10 +41412,10 @@
           "name": "p4"
         }
       ],
-      "return_type": "int"
+      "return_type": "Any"
     },
-    "0x147EA072": {
-      "name": "GET_ACTOR_PROOF",
+    "0x27A00456": {
+      "name": "_MP_DEED_START",
       "comment": "",
       "params": [
         {
@@ -39692,25 +41423,10 @@
           "name": "p0"
         }
       ],
-      "return_type": "int"
+      "return_type": "Any"
     },
-    "0xA5875DC8": {
-      "name": "SET_ACTOR_PROOF",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xF2F77F44": {
-      "name": "SET_ACTOR_OVERHEALTH_MODE",
+    "0x120E6123": {
+      "name": "_MP_DEED_COMPLETE",
       "comment": "",
       "params": [
         {
@@ -39718,21 +41434,10 @@
           "name": "p0"
         }
       ],
-      "return_type": "int"
+      "return_type": "Any"
     },
-    "0x437588E6": {
-      "name": "_REPAIR_INCAPACITATION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xEE4E2461": {
-      "name": "GET_ACTOR_INCAPACITATED",
+    "0x4585821E": {
+      "name": "_MP_DEED_COMPLETE_EX",
       "comment": "",
       "params": [
         {
@@ -39752,51 +41457,10 @@
           "name": "p3"
         }
       ],
-      "return_type": "int"
+      "return_type": "Any"
     },
-    "0x2D9C0C0F": {
-      "name": "SET_ALLOW_RIDE_BY_AI",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0318FF2A": {
-      "name": "GET_ALLOW_RIDE_BY_PLAYER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xCF1A1BC5": {
-      "name": "SET_ALLOW_RIDE_BY_PLAYER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "BOOL",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xF83A8D2B": {
-      "name": "SET_ALLOW_RIDE",
+    "0x46C39437": {
+      "name": "_MP_COOP_COMPLETE",
       "comment": "",
       "params": [
         {
@@ -39824,657 +41488,7 @@
           "name": "p5"
         }
       ],
-      "return_type": "int"
-    },
-    "0x0111E8E0": {
-      "name": "GET_ALLOW_RIDE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x5D5BD1F0": {
-      "name": "SET_ALLOW_JACK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x5896817B": {
-      "name": "SET_ALLOW_EXECUTE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xA1BFC1A5": {
-      "name": "SET_ALLOW_DEADEYE_LOCKS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x9375946B": {
-      "name": "SET_DEADEYE_LOCKS_ON_HEAD_ONLY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x740B78A8": {
-      "name": "SET_ALLOW_MELEE_SPECIAL_MOVE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7A11D611": {
-      "name": "SET_ALLOW_LASSO_MINI_GAME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x0666B436": {
-      "name": "ACTOR_DISMOUNT_NOW",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xBFD6AE3D": {
-      "name": "IS_ACTOR_REACTING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x6D322CD3": {
-      "name": "GET_ACTOR_UPDATE_PRIORITY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x44C05EF6": {
-      "name": "SET_ACTOR_UPDATE_PRIORITY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xA4E29C31": {
-      "name": "_0xA4E29C31",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5C7F63E3": {
-      "name": "ACTOR_FORCE_NEXT_UPDATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x87C49DBD": {
-      "name": "IS_ANY_ACTOR_IN_SPHERE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xB42EBC65": {
-      "name": "SET_NPC_TO_NPC_CRIPPLE_DISABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "result"
-        }
-      ],
       "return_type": "Any"
-    },
-    "0x135EA21D": {
-      "name": "SET_NPC_TO_NPC_DAMAGE_SCALE_FACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "float*"
-    },
-    "0xA393AC4E": {
-      "name": "SET_PLAYER_TO_PLAYER_DAMAGE_SCALE_FACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "float*"
-    },
-    "0x05CFE1E9": {
-      "name": "SET_NPC_TO_ACTOR_DAMAGE_SCALE_FACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x083903D1": {
-      "name": "SET_ACTOR_LOW_DROP_DAMAGE",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x1540A309": {
-      "name": "SET_ACTOR_MEDIUM_DROP_DAMAGE",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "p0"
-        },
-        {
-          "type": "int",
-          "name": "p1"
-        },
-        {
-          "type": "int",
-          "name": "p2"
-        },
-        {
-          "type": "int",
-          "name": "p3"
-        },
-        {
-          "type": "int",
-          "name": "p4"
-        },
-        {
-          "type": "int",
-          "name": "p5"
-        },
-        {
-          "type": "int",
-          "name": "p6"
-        },
-        {
-          "type": "int",
-          "name": "p7"
-        },
-        {
-          "type": "float",
-          "name": "p8"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7CC57FDA": {
-      "name": "SET_ACTOR_HIGH_DROP_DAMAGE",
-      "comment": "",
-      "params": [
-        {
-          "type": "int",
-          "name": "p0"
-        },
-        {
-          "type": "int",
-          "name": "p1"
-        },
-        {
-          "type": "int",
-          "name": "p2"
-        },
-        {
-          "type": "int",
-          "name": "p3"
-        },
-        {
-          "type": "int",
-          "name": "p4"
-        },
-        {
-          "type": "int",
-          "name": "p5"
-        },
-        {
-          "type": "int",
-          "name": "p6"
-        },
-        {
-          "type": "int",
-          "name": "p7"
-        },
-        {
-          "type": "float",
-          "name": "p8"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9F6B04C8": {
-      "name": "SET_ACTOR_DEATH_DROP_DISTANCE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xDA0CDC91": {
-      "name": "SET_DAMAGE_SCALE_ENABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x3AD31762": {
-      "name": "SET_CRIPPLE_ENABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0A9A99DF": {
-      "name": "SET_CRIPPLE_FLAG",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x38C5F63F": {
-      "name": "IS_ACTOR_CRIPPLED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xA5A24484": {
-      "name": "IS_ACTOR_HANDSUP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xA4677DD2": {
-      "name": "SET_ALLOW_COLD_WEATHER_BREATH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x1F0CD262": {
-      "name": "SET_DLC_FALLBACK_AVATAR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x1D1D9387": {
-      "name": "SET_EMOTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xC0F77310": {
-      "name": "SET_ACTOR_STOP_UPDATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x4EFC58BC": {
-      "name": "GET_ACTOR_STOP_UPDATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x22558E3F": {
-      "name": "IS_ACTOR_IN_ROOM",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x398735FA": {
-      "name": "REGISTER_TRAFFIC_OBJECTSET",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x67FA18A1": {
-      "name": "REGISTER_TRAFFIC_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x1444F022": {
-      "name": "REGISTER_GPS_CURVE_OBJECTSET",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4B90D22A": {
-      "name": "SET_PLAYER_TARGET_WEIGHT",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "float*"
-    },
-    "0xF1779E65": {
-      "name": "RESET_PLAYER_TARGET_WEIGHT",
-      "comment": "",
-      "params": [],
-      "return_type": "float*"
-    },
-    "0xA819497B": {
-      "name": "SET_HARDLOCK_TARGET_ANGLE_WEIGHTING",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int*"
-    },
-    "0x8BE2D8B0": {
-      "name": "SET_ZOMBIE_TARGET_MODE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x91BB8548": {
-      "name": "SET_ACTOR_SKIP_VISIBILITY_CHECK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8AE58EE1": {
-      "name": "GET_ACTOR_SKIP_VISIBILITY_CHECK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xDE0E96F3": {
-      "name": "FEED_CODE_WARP_DIST",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x968F0317": {
-      "name": "_0x968F0317",
-      "comment": "PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x0911BA31": {
-      "name": "SET_ACTOR_STREAMING_HIGH_PRIORITY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
     }
   },
   "POPULATION": {
@@ -41105,13 +42119,92 @@
       "return_type": "int"
     }
   },
-  "OBJECT2": {
-    "0x7080E24A": {
-      "name": "_0x7080E24A",
+  "PPPELEMENTS": {
+    "0x598815BD": {
+      "name": "_0x598815BD",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xD1C91A7F": {
+      "name": "_0xD1C91A7F",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        }
+      ],
+      "return_type": "const char*"
+    },
+    "0x7E0CDD87": {
+      "name": "_0x7E0CDD87",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xE6C1DBD9": {
+      "name": "_0xE6C1DBD9",
       "comment": "",
       "params": [
         {
           "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x00EF33EF": {
+      "name": "_0x00EF33EF",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xDF505043": {
+      "name": "_0xDF505043",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "result"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xE613AE52": {
+      "name": "_0xE613AE52",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x84F3DD81": {
+      "name": "_0x84F3DD81",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
           "name": "p0"
         },
         {
@@ -41119,14 +42212,36 @@
           "name": "p1"
         }
       ],
-      "return_type": "int"
+      "return_type": "void"
     },
-    "0x1D7845B7": {
-      "name": "_0x1D7845B7",
+    "0xF55B50ED": {
+      "name": "_0xF55B50ED",
       "comment": "",
       "params": [
         {
           "type": "Any",
+          "name": "result"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x6336182D": {
+      "name": "_0x6336182D",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x3A6960B2": {
+      "name": "_0x3A6960B2",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
           "name": "p0"
         }
       ],
@@ -41600,43 +42715,9 @@
       "return_type": "Any"
     }
   },
-  "TARGETING": {
-    "0x86BAAC6C": {
-      "name": "GET_ACTOR_UNDER_RETICLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "int*",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8AE7281E": {
-      "name": "GET_RETICLE_TARGET_POINT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Vector3*",
-          "name": "coords"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5F566576": {
-      "name": "SET_PLAYER_PERFECT_ACCURACY",
+  "RIDING": {
+    "0x00AF2CB0": {
+      "name": "SET_MOST_RECENT_MOUNT",
       "comment": "",
       "params": [
         {
@@ -41648,298 +42729,134 @@
           "name": "p1"
         }
       ],
-      "return_type": "int"
+      "return_type": "void"
     },
-    "0xD95C01D2": {
-      "name": "OVERRIDE_PLAYER_TARGETING_WEIGHTS",
+    "0x708E450F": {
+      "name": "GET_MOST_RECENT_MOUNT",
       "comment": "",
       "params": [
         {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "float",
-          "name": "p8"
-        },
-        {
-          "type": "float",
-          "name": "p9"
+          "type": "Actor",
+          "name": "actor"
         }
       ],
-      "return_type": "int"
+      "return_type": "Any"
     },
-    "0x91220723": {
-      "name": "SET_ACTOR_BASE_SCORE",
+    "0x668E55C3": {
+      "name": "GET_MOST_RECENT_RIDER",
       "comment": "",
       "params": [
         {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
+          "type": "Actor",
+          "name": "actor"
         }
       ],
-      "return_type": "int"
+      "return_type": "Any"
     },
-    "0x856C3A8A": {
-      "name": "SET_ACTOR_HARDLOCK_BIAS",
+    "0xDB0D0478": {
+      "name": "IS_ACTOR_HORSE",
       "comment": "",
       "params": [
         {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x6400E005": {
-      "name": "SET_ACTOR_USE_FULLSCREEN_ACQUISITION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xF1607937": {
-      "name": "SET_ACTOR_CAN_BE_TARGETED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x0753A098": {
-      "name": "SET_ACTOR_CAN_BE_TARGETED_CASUAL_ONLY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xF4429710": {
-      "name": "_0xF4429710",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x1468DD56": {
-      "name": "_0x1468DD56",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
+          "type": "Actor",
+          "name": "actor"
         }
       ],
       "return_type": "BOOL"
     },
-    "0x327E4426": {
-      "name": "SET_ACTOR_CAN_BE_SOFTLOCKED",
+    "0x1F739295": {
+      "name": "IS_ACTOR_MULE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xA6BBE769": {
+      "name": "IS_ACTOR_RIDING",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0xF270EAC1": {
+      "name": "IS_ACTOR_RIDING_AND_IN_SADDLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xA3AB3708": {
+      "name": "IS_ACTOR_MOUNTED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x88A283E5": {
+      "name": "GET_RIDER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xDD31EC4E": {
+      "name": "GET_MOUNT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "Actor"
+    },
+    "0xDC6DEE92": {
+      "name": "SET_MOUNTS_AS_PASSENGER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xC28242F4": {
+      "name": "ACTOR_MOUNT_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Actor",
+          "name": "actor2"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x374D047A": {
+      "name": "REMOVE_HORSE_ACCESSORY",
       "comment": "",
       "params": [
         {
@@ -41965,20 +42882,12 @@
         {
           "type": "Any",
           "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
         }
       ],
-      "return_type": "int"
+      "return_type": "Any"
     },
-    "0xAC8D3A0C": {
-      "name": "SET_ACTOR_CAN_BE_AIMASSISTED",
+    "0x75D4E33F": {
+      "name": "DOES_HORSE_HAVE_ACCESSORY",
       "comment": "",
       "params": [
         {
@@ -41990,10 +42899,10 @@
           "name": "p1"
         }
       ],
-      "return_type": "void"
+      "return_type": "Any"
     },
-    "0x57055A7D": {
-      "name": "SET_ACTOR_CAN_BE_BUMPTARGETED",
+    "0x6C939AA7": {
+      "name": "ACCESSORIZE_HORSE",
       "comment": "",
       "params": [
         {
@@ -42005,10 +42914,10 @@
           "name": "p1"
         }
       ],
-      "return_type": "void"
+      "return_type": "Any"
     },
-    "0x5CC16A49": {
-      "name": "_0x5CC16A49",
+    "0x6B6E05A8": {
+      "name": "HORSE_ENABLE_AUTO_JUMP_FOR_AI_RIDERS",
       "comment": "",
       "params": [
         {
@@ -42020,16 +42929,10 @@
           "name": "p1"
         }
       ],
-      "return_type": "void"
+      "return_type": "Any"
     },
-    "0x7E124E62": {
-      "name": "_0x7E124E62",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x1EEE7494": {
-      "name": "_0x1EEE7494",
+    "0xCA7CB126": {
+      "name": "HORSE_AUTO_JUMP_ENABLED_FOR_AI_RIDERS",
       "comment": "",
       "params": [
         {
@@ -42041,10 +42944,32 @@
           "name": "p1"
         }
       ],
-      "return_type": "void"
+      "return_type": "Any"
     },
-    "0xD19EFFC1": {
-      "name": "CALCULATE_NORMALIZED_SCREEN_DISTANCE_FROM_RETICLE",
+    "0x28FCBDF2": {
+      "name": "HORSE_ADD_REPULSION_EXCLUSION_VOLUME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x5DE07F18": {
+      "name": "HORSE_REMOVE_REPULSION_EXCLUSION_VOLUME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xF3976D70": {
+      "name": "HORSE_SET_CURR_FRESHNESS",
       "comment": "",
       "params": [
         {
@@ -42056,7 +42981,51 @@
           "name": "p1"
         }
       ],
-      "return_type": "float"
+      "return_type": "Any"
+    },
+    "0xB8665D8A": {
+      "name": "HORSE_GET_CURR_FRESHNESS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x8754817D": {
+      "name": "HORSE_LOCK_FRESHNESS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x6AFA044B": {
+      "name": "HORSE_UNLOCK_FRESHNESS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xB731EB45": {
+      "name": "HORSE_SET_INFINITE_FRESHNESS_CHEAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "BOOL",
+          "name": "toggle"
+        }
+      ],
+      "return_type": "void"
     }
   },
   "SHOP": {
@@ -42505,9 +43474,9 @@
       "return_type": "int"
     }
   },
-  "PHYSICS": {
-    "0x17B69196": {
-      "name": "GET_PHYSINST_VELOCITY",
+  "SOCIALCLUB": {
+    "0x1EB9AF29": {
+      "name": "UI_CHALLENGE_CREATE",
       "comment": "",
       "params": [
         {
@@ -42517,23 +43486,16 @@
         {
           "type": "Any",
           "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xAFB1DFA2": {
-      "name": "IS_PHYSINST_ACTIVE",
-      "comment": "",
-      "params": [
+        },
         {
           "type": "Any",
-          "name": "p0"
+          "name": "p2"
         }
       ],
-      "return_type": "BOOL"
+      "return_type": "void"
     },
-    "0x38636EBF": {
-      "name": "SET_PHYSINST_COLLIDES_AGAINST_INACTIVE",
+    "0x2A39FD8A": {
+      "name": "UI_CHALLENGE_SET_DESCRIPTION",
       "comment": "",
       "params": [
         {
@@ -42547,71 +43509,8 @@
       ],
       "return_type": "void"
     },
-    "0x2C0AF634": {
-      "name": "SET_PHYSINST_FROZEN",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x789AA2B2": {
-      "name": "IS_PHYSINST_FROZEN",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xEBD9DFE6": {
-      "name": "SET_PHYSINST_HIDE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x445990D8": {
-      "name": "IS_PHYSINST_HIDE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xB5F9F4CF": {
-      "name": "BREAK_OFF_ABOVE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0BA5E579": {
-      "name": "GET_LOCATOR_OFFSETS",
+    "0xD5ED5FCB": {
+      "name": "UI_CHALLENGE_SET_TITLE_TEXTURE",
       "comment": "",
       "params": [
         {
@@ -42633,157 +43532,8 @@
       ],
       "return_type": "int"
     },
-    "0xFD759593": {
-      "name": "_0xFD759593",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x87A2C1D5": {
-      "name": "SET_GLOBAL_DISABLE_SPU_COLLIDER_UPDATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x374DE883": {
-      "name": "SET_GLOBAL_AGGRESSIVE_CORPSE_RECYCLING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x89B45C7D": {
-      "name": "LIQUID_TEST_SET_VELOCITY_SCALE",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x4C02E1E5": {
-      "name": "CLEAN_CACHE_ENTRIES",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    }
-  },
-  "GAME": {
-    "0x6FCF6BC8": {
-      "name": "DISABLE_PLAYER_GRINGO_USE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x5A9D0738": {
-      "name": "IS_MISSION_SCRIPT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x15040CD2": {
-      "name": "SET_IS_MISSION_SCRIPT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x45589499": {
-      "name": "_0x45589499",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xDD9BD22B": {
-      "name": "GET_GAME_STATE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x9B71351C": {
-      "name": "SET_PAUSE_SCRIPT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xFEA58D57": {
-      "name": "ENABLE_USE_CONTEXTS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x2ADA3DD4": {
-      "name": "ARE_USE_CONTEXTS_ENABLED",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x115CD0CC": {
-      "name": "IS_SCRIPT_USE_CONTEXT_VALID",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x039E7F1D": {
-      "name": "ADD_SCRIPT_USE_CONTEXT_IN_VOLUME",
+    "0x10F5386D": {
+      "name": "UI_CHALLENGE_SET_PROGRESS",
       "comment": "",
       "params": [
         {
@@ -42805,132 +43555,77 @@
         {
           "type": "Any",
           "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        },
-        {
-          "type": "Any",
-          "name": "p9"
-        },
-        {
-          "type": "Any",
-          "name": "p10"
-        },
-        {
-          "type": "Any",
-          "name": "p11"
-        },
-        {
-          "type": "Any",
-          "name": "p12"
-        },
-        {
-          "type": "Any",
-          "name": "p13"
-        },
-        {
-          "type": "Any",
-          "name": "p14"
-        },
-        {
-          "type": "Any",
-          "name": "p15"
         }
       ],
-      "return_type": "Any"
+      "return_type": "void"
     },
-    "0xD7591B0E": {
-      "name": "ADD_SCRIPT_USE_CONTEXT",
+    "0x9D9CDCE3": {
+      "name": "UI_CHALLENGE_SET_PROGRESS_DETAIL",
       "comment": "",
       "params": [
         {
-          "type": "const char*",
-          "name": "gxtName"
+          "type": "Any",
+          "name": "p0"
         },
         {
           "type": "Any",
           "name": "p1"
         },
         {
-          "type": "int",
-          "name": "button"
+          "type": "Any",
+          "name": "p2"
         },
         {
           "type": "Any",
           "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x3731AC9F": {
+      "name": "UI_CHALLENGE_SET_TROPHY_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
         },
         {
           "type": "Any",
-          "name": "p4"
+          "name": "p1"
         },
         {
           "type": "Any",
-          "name": "p5"
+          "name": "p2"
         },
         {
           "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "int",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
+          "name": "p3"
         }
       ],
       "return_type": "int"
     },
-    "0xF48F8F09": {
-      "name": "_0xF48F8F09",
+    "0x9CF5C747": {
+      "name": "UI_CHALLENGE_SET_OBJECTIVE",
       "comment": "",
       "params": [
         {
           "type": "Any",
           "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x45C1C061": {
-      "name": "IS_SCRIPT_USE_CONTEXT_PRESSED",
-      "comment": "",
-      "params": [
+        },
         {
           "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x971559CA": {
-      "name": "WAS_SCRIPT_USE_CONTEXT_EVER_PRESSED",
-      "comment": "",
-      "params": [
+          "name": "p1"
+        },
         {
           "type": "Any",
-          "name": "p0"
+          "name": "p2"
         }
       ],
-      "return_type": "Any"
+      "return_type": "void"
     },
-    "0x3ECD8FEE": {
-      "name": "SET_USE_CONTEXT_TEXT",
+    "0x4A598723": {
+      "name": "UI_CHALLENGE_SET_OBJECTIVE_STYLE",
       "comment": "",
       "params": [
         {
@@ -42948,204 +43643,12 @@
         {
           "type": "Any",
           "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
         }
       ],
-      "return_type": "Any"
+      "return_type": "int"
     },
-    "0x4F52CB58": {
-      "name": "RELEASE_SCRIPT_USE_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xA3E1EF71": {
-      "name": "NET_MAILBOX_IS_SIGNED_INTO_SC",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x6B439149": {
-      "name": "NET_MAILBOX_GET_MAX_NUM_CHALLENGES",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x89F1B8CD": {
-      "name": "NET_MAILBOX_GET_NUM_CHALLENGES",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0xE85942F0": {
-      "name": "NET_MAILBOX_GET_CHALLENGE_BY_INDEX",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xD4FBCCE0": {
-      "name": "NET_MAILBOX_GET_CHALLENGE_BY_ID",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xC9E96F78": {
-      "name": "NET_MAILBOX_IS_CHALLENGE_VALID",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xCBBE41DD": {
-      "name": "SC_CHALLENGE_LAUNCH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xB7DE2AF2": {
-      "name": "SC_CHALLENGE_CLEAN_UP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x79F09AC7": {
-      "name": "SC_CHALLENGE_IS_RUNNING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x5D7197BC": {
-      "name": "SC_CHALLENGE_IS_ACTIVE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xFFC55DA4": {
-      "name": "SC_CHALLENGE_GET_COMMUNITY_TOTAL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xCEEEAE1D": {
-      "name": "SC_CHALLENGE_GET_COMMUNITY_VALUE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x1876B04E": {
-      "name": "SC_CHALLENGE_PROCESS_EXPIRATION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x4BD61354": {
-      "name": "SC_CHALLENGE_GET_EXPIRATION_STATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xF5F97702": {
-      "name": "SC_CHALLENGE_RESET_EXPIRATION_STATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xFD6197EB": {
-      "name": "SC_CHALLENGE_IS_VAR_VALID",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xC322556E": {
-      "name": "SC_CHALLENGE_GET_VAR_FLOAT",
+    "0x9272926C": {
+      "name": "UI_CHALLENGE_SET_OBJECTIVE_STYLE_B",
       "comment": "",
       "params": [
         {
@@ -43159,53 +43662,16 @@
         {
           "type": "Any",
           "name": "p2"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x2390DD18": {
-      "name": "SC_CHALLENGE_GET_VAR_INT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
         },
         {
           "type": "Any",
-          "name": "p1"
+          "name": "p3"
         }
       ],
-      "return_type": "Any"
+      "return_type": "int"
     },
-    "0xB40622F1": {
-      "name": "SC_CHALLENGE_GET_VAR_BOOL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xD2513200": {
-      "name": "SC_CHALLENGE_RELEASE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xC21048BF": {
-      "name": "SC_CHALLENGE_GET_LEADERBOARD_ID",
+    "0xAFC9071D": {
+      "name": "UI_CHALLENGE_SET_COLUMN_HEADER",
       "comment": "",
       "params": [
         {
@@ -43219,12 +43685,62 @@
         {
           "type": "Any",
           "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
         }
       ],
-      "return_type": "Any"
+      "return_type": "int"
     },
-    "0x5725C84F": {
-      "name": "SC_CHALLENGE_GET_MIN_LB_REFRESH_DELAY_SECS",
+    "0x761A6750": {
+      "name": "UI_CHALLENGE_SET_TIME_HEADER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC201524D": {
+      "name": "UI_CHALLENGE_SET_TIME_INFO",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x04A3022E": {
+      "name": "UI_CHALLENGE_MAKE_CURRENT",
       "comment": "",
       "params": [
         {
@@ -43232,18 +43748,7 @@
           "name": "p0"
         }
       ],
-      "return_type": "Any"
-    },
-    "0x2374C1E0": {
-      "name": "SC_CHALLENGE_GET_MIN_SUBMIT_DELAY_SECS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
+      "return_type": "void"
     }
   },
   "SQUADS": {
@@ -46114,6 +46619,859 @@
       "return_type": "int"
     }
   },
+  "SYSTEM": {
+    "0x7715C03B": {
+      "name": "WAIT",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "ms"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x01185F9B": {
+      "name": "WAITUNWARPED",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "ms"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7C496803": {
+      "name": "WAITUNPAUSED",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "ms"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x3F166D0E": {
+      "name": "START_NEW_SCRIPT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x4A2100E4": {
+      "name": "START_NEW_SCRIPT_WITH_ARGS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x35785333": {
+      "name": "SETTIMERA",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x50597EE2": {
+      "name": "TIMESTEP",
+      "comment": "",
+      "params": [],
+      "return_type": "Any"
+    },
+    "0xECF8EB5F": {
+      "name": "PRINTSTRING",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "value"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xD48B90B6": {
+      "name": "PRINTFLOAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "value"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x63651F03": {
+      "name": "PRINTINT",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "value"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x868997DA": {
+      "name": "PRINTNL",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x85F31FB": {
+      "name": "PRINTVECTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x145C7701": {
+      "name": "SQRT",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "value"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0x85D134F8": {
+      "name": "POW",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "base"
+        },
+        {
+          "type": "float",
+          "name": "exponent"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0xE2313450": {
+      "name": "EXP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x1FCF1ECD": {
+      "name": "VMAG",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0x3C08ECB7": {
+      "name": "VDIST",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "x1"
+        },
+        {
+          "type": "float",
+          "name": "y1"
+        },
+        {
+          "type": "float",
+          "name": "z1"
+        },
+        {
+          "type": "float",
+          "name": "x2"
+        },
+        {
+          "type": "float",
+          "name": "y2"
+        },
+        {
+          "type": "float",
+          "name": "z2"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0xC85DEF1F": {
+      "name": "VDIST2",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "x1"
+        },
+        {
+          "type": "float",
+          "name": "y1"
+        },
+        {
+          "type": "float",
+          "name": "z1"
+        },
+        {
+          "type": "float",
+          "name": "x2"
+        },
+        {
+          "type": "float",
+          "name": "y2"
+        },
+        {
+          "type": "float",
+          "name": "z2"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0x314CC6CD": {
+      "name": "SHIFT_LEFT",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "value"
+        },
+        {
+          "type": "int",
+          "name": "bitShift"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x352633CA": {
+      "name": "SHIFT_RIGHT",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "value"
+        },
+        {
+          "type": "int",
+          "name": "bitShift"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x32E9BE04": {
+      "name": "FLOOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "value"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xD536A1DF": {
+      "name": "CEIL",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "value"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x323B0E24": {
+      "name": "ROUND",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "value"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x67116627": {
+      "name": "TO_FLOAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "int",
+          "name": "value"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0x5A25520E": {
+      "name": "SNAPSHOT_GLOBALS",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x2B547FE6": {
+      "name": "GET_LATEST_CONSOLE_COMMAND",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xAA3EC981": {
+      "name": "RESET_LATEST_CONSOLE_COMMAND",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x9DE3DE24": {
+      "name": "GET_CONSOLE_COMMAND_TOKEN",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x608F5BC6": {
+      "name": "GET_NUM_CONSOLE_COMMAND_TOKENS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    }
+  },
+  "TARGETING": {
+    "0x86BAAC6C": {
+      "name": "GET_ACTOR_UNDER_RETICLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "int*",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8AE7281E": {
+      "name": "GET_RETICLE_TARGET_POINT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Vector3*",
+          "name": "coords"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5F566576": {
+      "name": "SET_PLAYER_PERFECT_ACCURACY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xD95C01D2": {
+      "name": "OVERRIDE_PLAYER_TARGETING_WEIGHTS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "float",
+          "name": "p8"
+        },
+        {
+          "type": "float",
+          "name": "p9"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x91220723": {
+      "name": "SET_ACTOR_BASE_SCORE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x856C3A8A": {
+      "name": "SET_ACTOR_HARDLOCK_BIAS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x6400E005": {
+      "name": "SET_ACTOR_USE_FULLSCREEN_ACQUISITION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xF1607937": {
+      "name": "SET_ACTOR_CAN_BE_TARGETED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x0753A098": {
+      "name": "SET_ACTOR_CAN_BE_TARGETED_CASUAL_ONLY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xF4429710": {
+      "name": "_0xF4429710",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x1468DD56": {
+      "name": "_0x1468DD56",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x327E4426": {
+      "name": "SET_ACTOR_CAN_BE_SOFTLOCKED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xAC8D3A0C": {
+      "name": "SET_ACTOR_CAN_BE_AIMASSISTED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x57055A7D": {
+      "name": "SET_ACTOR_CAN_BE_BUMPTARGETED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x5CC16A49": {
+      "name": "_0x5CC16A49",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7E124E62": {
+      "name": "_0x7E124E62",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x1EEE7494": {
+      "name": "_0x1EEE7494",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xD19EFFC1": {
+      "name": "CALCULATE_NORMALIZED_SCREEN_DISTANCE_FROM_RETICLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "float"
+    }
+  },
   "TASKS": {
     "0xE32F09B3": {
       "name": "TASK_ACTION_PERFORM",
@@ -48976,6 +50334,19 @@
       "return_type": "Any"
     }
   },
+  "TURRET": {
+    "0x2C5983E0": {
+      "name": "IS_USING_TURRET",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    }
+  },
   "UI": {
     "0x97A50E69": {
       "name": "_0x97A50E69",
@@ -49684,989 +51055,6 @@
           "name": "p0"
         }
       ],
-      "return_type": "int"
-    }
-  },
-  "AI_SPEECH2": {
-    "0xD85BAFA8": {
-      "name": "SPEECH_CONTEXT_INIT_DATA",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xEB99D1A9": {
-      "name": "SPEECH_CONTEXT_ADD_CHILD",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0386C556": {
-      "name": "SPEECH_CONTEXT_SET_TIME_RESTRICTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xF63FA0A1": {
-      "name": "SPEECH_CONTEXT_SET_OPPOSITE_GENDER_RESTRICTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xB59AD5B1": {
-      "name": "GET_LOCKON_MISSION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4F64116B": {
-      "name": "_0x4F64116B",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xBAD8B9A8": {
-      "name": "SPEECH_CONTEXT_SET_WEATHER_RESTRICTION_GOOD",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x6CBF76AB": {
-      "name": "SPEECH_CONTEXT_SET_WEATHER_RESTRICTION_RAINY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE0DD373F": {
-      "name": "SPEECH_CONTEXT_SET_TARGET_PLAYER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x3C6FE75D": {
-      "name": "_0x3C6FE75D",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x74E7F898": {
-      "name": "SPEECH_CONTEXT_SET_PLAYER_IDENTITY_RESTRICTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xA13D379B": {
-      "name": "SPEECH_CONTEXT_SET_ALLOW_PHRASE_REUSE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xAC72E757": {
-      "name": "_0xAC72E757",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x99AFD2D1": {
-      "name": "_0x99AFD2D1",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    }
-  },
-  "GREETING": {
-    "0x9953D4FC": {
-      "name": "SET_GREETING_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x751809BB": {
-      "name": "SET_NON_VERBAL_GREETING_PROBABILITY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x25A42C69": {
-      "name": "_0x25A42C69",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x40121E4F": {
-      "name": "_0x40121E4F",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x86CB8CFB": {
-      "name": "_0x86CB8CFB",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xD6AD0016": {
-      "name": "_0xD6AD0016",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xDE84B637": {
-      "name": "_0xDE84B637",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x8C00C0BE": {
-      "name": "_0x8C00C0BE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x7CC67B30": {
-      "name": "_0x7CC67B30",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xD4ECD97D": {
-      "name": "_0xD4ECD97D",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x826BB889": {
-      "name": "_0x826BB889",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x5473B93A": {
-      "name": "_0x5473B93A",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x1B1EFCCB": {
-      "name": "_0x1B1EFCCB",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    }
-  },
-  "AI_CONVERSE": {
-    "0x30402375": {
-      "name": "AI_CONVERSE_SET_GREETING_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x7922F870": {
-      "name": "AI_CONVERSE_SET_GOSSIP_AMBIENT_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x663723A0": {
-      "name": "AI_CONVERSE_SET_GOSSIP_REPLY_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x93CFB180": {
-      "name": "AI_CONVERSE_SET_GOODBYE_START_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xA1FCBA24": {
-      "name": "AI_CONVERSE_SET_GOODBYE_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x7ED8B78C": {
-      "name": "AI_CONVERSE_INIT_CAMPFIRE_CONTEXT_STORAGE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xD4871BDB": {
-      "name": "AI_CONVERSE_SET_CAMPFIRE_INVITE_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xA88359B9": {
-      "name": "AI_CONVERSE_SET_CAMPFIRE_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xAD42EABC": {
-      "name": "AI_CONVERSE_SET_CAMPFIRE_STORY_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC65F6751": {
-      "name": "AI_CONVERSE_SET_CAMPFIRE_STORY_DONE_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x83CBD612": {
-      "name": "AI_CONVERSE_SET_CAMPFIRE_STORY_LEAVE_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x4AD2BC30": {
-      "name": "AI_CONVERSE_SET_CAMPFIRE_RESPONSE_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xC1F9A360": {
-      "name": "AI_SET_CAMPFIRE_STORY_ENABLED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xFCD2DE48": {
-      "name": "AI_CONVERSE_SET_GIDDYUP_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xB8F1D736": {
-      "name": "AI_CONVERSE_SET_WOAH_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xEA86A817": {
-      "name": "AI_CONVERSE_DISABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x43F59172": {
-      "name": "AI_CONVERSE_ENABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x52D984AF": {
-      "name": "AI_CONVERSE_ADD_CAMPFIRE_CONVERSER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x1D4786CF": {
-      "name": "AI_CONVERSE_REMOVE_CAMPFIRE_CONVERSER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x375BBD85": {
-      "name": "AI_CONVERSE_SET_GREET_SAUCY_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x4819FB7C": {
-      "name": "AI_CONVERSE_SET_SOLICIT_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xC4F468AA": {
-      "name": "AI_CONVERSE_SET_REJECTION_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xBD3A0E6D": {
-      "name": "GAME_ESTIMATE_MOUNT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xD6BBC8AA": {
-      "name": "AI_CONVERSE_SET_GREET_PLAYER_CONTEXT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    }
-  },
-  "PLAYERNAMES": {
-    "0x77D6ABF5": {
-      "name": "NET_GAMER_SET_ACTOR_OVERRIDE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE79F6CD4": {
-      "name": "NET_GAMER_SET_TEAM",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xFD91BE0D": {
-      "name": "_0xFD91BE0D",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE2E6C722": {
-      "name": "IN_SELECTED_PEDPATH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xCE8F6304": {
-      "name": "_0xCE8F6304",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xAB32D5D9": {
-      "name": "_0xAB32D5D9",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7BD7A465": {
-      "name": "NET_GAMER_SET_TITLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x2357CA74": {
-      "name": "_0x2357CA74",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x160E79C6": {
-      "name": "_0x160E79C6",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xB5DDEF68": {
-      "name": "_0xB5DDEF68",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x34960D06": {
-      "name": "_0x34960D06",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE783219A": {
-      "name": "_0xE783219A",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x1958F478": {
-      "name": "END_SCRIPTED_REQUEST",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x2FB85996": {
-      "name": "_0x2FB85996",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xF34B8448": {
-      "name": "_0xF34B8448",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x796E66E7": {
-      "name": "_0x796E66E7",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x650A7440": {
-      "name": "_GROUP_COLOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xA0A5FF80": {
-      "name": "NET_GAMER_SET_ICON_STEALTH_OVERRIDE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x2634F265": {
-      "name": "NET_GAMER_SET_BLIP_STEALTH_OVERRIDE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x4A2E7533": {
-      "name": "IS_HORSES_RELATIVE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x08D84437": {
-      "name": "_0x08D84437",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x784F04DD": {
-      "name": "_0x784F04DD",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x3DD6E36A": {
-      "name": "_0x3DD6E36A",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE5FE0A6A": {
-      "name": "_0xE5FE0A6A",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x25F8C46A": {
-      "name": "_0x25F8C46A",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x3248D20E": {
-      "name": "_0x3248D20E",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x9DDB29B1": {
-      "name": "NET_POSSE_GET_LEADER_WAYPOINT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x24A1B923": {
-      "name": "NET_POSSE_IS_LEADER_WAYPOINT_VALID",
-      "comment": "",
-      "params": [],
       "return_type": "int"
     }
   },
@@ -51675,19 +52063,6 @@
       "return_type": "Any"
     }
   },
-  "TURRET": {
-    "0x2C5983E0": {
-      "name": "IS_USING_TURRET",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    }
-  },
   "VOLUME": {
     "0xBC33CEB5": {
       "name": "IS_VOLUME_VALID",
@@ -51861,1135 +52236,6 @@
         }
       ],
       "return_type": "int"
-    }
-  },
-  "INVENTORY": {
-    "0xBAA5D41B": {
-      "name": "ADD_ITEM",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "ItemName"
-        },
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xAB2D8A68": {
-      "name": "ADD_ITEM_BY_CRC",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x7609A328": {
-      "name": "HAS_INVENTORY_COMPONENT",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0xD91ED898": {
-      "name": "GET_ITEM_COUNT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x4BB2BC20": {
-      "name": "GET_ITEM_COUNT_BY_CRC",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xF52BA99F": {
-      "name": "GET_MAX_ITEM_COUNT",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0xE712FCB": {
-      "name": "SET_MAX_ITEM_COUNT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x5ACC0171": {
-      "name": "ADD_ACCESSORY",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xF750D150": {
-      "name": "ADD_ACCESSORY_BY_CRC",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xF05D1566": {
-      "name": "ADD_COLLECTABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x5889EBB7": {
-      "name": "REMOVE_COLLECTABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x2B00A643": {
-      "name": "READY_ITEM",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "ItemName"
-        },
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xB426267D": {
-      "name": "HAS_ITEM",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xC38F697": {
-      "name": "HAS_ACCESSORY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xEFECF4F9": {
-      "name": "DELETE_ITEM",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xD6A9C9D4": {
-      "name": "DELETE_ACCESSORY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x7BF75BCE": {
-      "name": "_0x7BF75BCE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x7F4D5AE0": {
-      "name": "_0x7F4D5AE0",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x608DCAEF": {
-      "name": "_0x608DCAEF",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x50C0E83F": {
-      "name": "IS_ITEM_WEAPON_BY_CRC",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x3A899B0E": {
-      "name": "GET_ITEM_IN_HAND_EQUIPSLOT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x0E0EFB13": {
-      "name": "_GET_AN_EQUIP_SLOT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x5E38B33C": {
-      "name": "ACTOR_DISABLE_WEAPON_RENDER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x1511D111": {
-      "name": "ACTOR_FORCE_WEAPON_RENDER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xAB5FB5AC": {
-      "name": "IS_WEAPON_DRAWN",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x6AA0EAF2": {
-      "name": "GIVE_WEAPON_TO_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "int",
-          "name": "weaponId"
-        },
-        {
-          "type": "int",
-          "name": "ammoCount"
-        },
-        {
-          "type": "BOOL",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xBFD6D55F": {
-      "name": "ACTOR_SET_NEXT_WEAPON",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x8F4B473D": {
-      "name": "ACTOR_PUT_WEAPON_IN_HAND",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x09950C1B": {
-      "name": "ACTOR_HAS_WEAPON_IN_HAND",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x13A63AA7": {
-      "name": "ACTOR_PUT_ITEM_AWAY",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x78145528": {
-      "name": "_0x78145528",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x5CAFCBD4": {
-      "name": "_0x5CAFCBD4",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x3417766E": {
-      "name": "_0x3417766E",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0xCC02BBD3": {
-      "name": "_0xCC02BBD3",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0xA8040D70": {
-      "name": "_0xA8040D70",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x659532FB": {
-      "name": "ACTOR_GET_BEST_WEAPON_OF_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xCB017277": {
-      "name": "DELETE_WEAPON_FROM_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x42C0FAAA": {
-      "name": "GET_WEAPON_EQUIPPED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x6262DC5E": {
-      "name": "GET_WEAPON_IS_EXTERNALLY_CREATED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xA4B2016D": {
-      "name": "GET_WEAPON_IN_HAND",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xCDD6F94": {
-      "name": "GET_WEAPON_IN_HAND_CRC",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x612066E5": {
-      "name": "_0x612066E5",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x2776B0F5": {
-      "name": "GET_WEAPON_ENUM_FROM_CRC",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xFD46B231": {
-      "name": "ACTOR_USE_ITEM_NOW",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xE6604B39": {
-      "name": "SET_EQUIP_SLOT_ENABLED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xA3E18517": {
-      "name": "GET_EQUIP_SLOT_ENABLED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x5A80659D": {
-      "name": "EQUIP_ACCESSORY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xF7696B8B": {
-      "name": "DEEQUIP_ACCESSORY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x9B958A25": {
-      "name": "HAS_ACCESSORY_ENUM",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xE094DB31": {
-      "name": "_0xE094DB31",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x7FDDF876": {
-      "name": "DROP_ACCESSORY_ENUM",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x8266C617": {
-      "name": "ACTOR_SET_WEAPON_AMMO",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "int",
-          "name": "weaponId"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xB008EF49": {
-      "name": "ACTOR_SET_WEAPON_AMMO_BY_CRC",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x0D47CFBD": {
-      "name": "ACTOR_HAS_WEAPON",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xCC69DCC1": {
-      "name": "ACTOR_ADD_WEAPON_AMMO",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "int",
-          "name": "weaponId"
-        },
-        {
-          "type": "int",
-          "name": "ammo"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x43DEDFAE": {
-      "name": "ACTOR_GET_WEAPON_AMMO",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xEEC81873": {
-      "name": "ACTOR_DISCARD_WEAPON_AMMO",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xA091179F": {
-      "name": "ACTOR_HAS_VARIABLE_MESH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x17883570": {
-      "name": "GET_AMMOENUM_FOR_WEAPONENUM",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xA8F64D32": {
-      "name": "GET_WEAPONENUM_FOR_AMMOENUM",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xAE44869D": {
-      "name": "SET_WEAPON_GOLD",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "int",
-          "name": "weaponId"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x6DBD1DDB": {
-      "name": "GET_WEAPON_GOLD",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "int",
-          "name": "weapon"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x80B30545": {
-      "name": "IS_GOLDEN_GUNS_ON",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x195A4286": {
-      "name": "FIRE_PROJECTILE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "int",
-          "name": "weapGroup"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "Vector3*",
-          "name": "origin"
-        },
-        {
-          "type": "Vector3*",
-          "name": "target"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x98B3ABFA": {
-      "name": "_ADD_AMMO_OF_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x4372593E": {
-      "name": "_SET_ACTOR_AMMO_OF_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x6ADAAD87": {
-      "name": "_SET_ACTOR_MAX_AMMO_AMOUNT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4FE2B586": {
-      "name": "_SET_ACTOR_INFINITE_AMMO_FLAG",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "int",
-          "name": "weaponGroup"
-        },
-        {
-          "type": "BOOL",
-          "name": "toggle"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE224AC6F": {
-      "name": "IS_FRONTEND_DEATH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x7AB368CF": {
-      "name": "_GET_MAX_AMMO_AMOUNT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xC666B987": {
-      "name": "_GET_ACTOR_INFINITE_AMMO_FLAG",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xBE39208A": {
-      "name": "ACTOR_SHOULD_DROP_ITEMS_ON_DEATH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xBC46E3E1": {
-      "name": "ACTOR_SET_DROP_ITEM_ON_DEATH_ENUMERATED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xBF0235B0": {
-      "name": "CREATE_WEAPON_PICKUP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x04BF00F0": {
-      "name": "REMOVE_ALL_PICKUPS",
-      "comment": "",
-      "params": [],
-      "return_type": "void"
-    },
-    "0x118D085E": {
-      "name": "GET_NUM_WEAPONS_IN_INVENTORY",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x78A3CD3D": {
-      "name": "_0x78A3CD3D",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x2C23CBE7": {
-      "name": "_0x2C23CBE7",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0xD695F857": {
-      "name": "_REMOVE_WEAPON",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x96AC812B": {
-      "name": "_0x96AC812B",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x5AEB2E4F": {
-      "name": "_REMOVE_HAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x3E8E7D7B": {
-      "name": "SETUP_ASSOCIATED_FRAGMENTS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x7BF01CCB": {
-      "name": "_0x7BF01CCB",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
-    },
-    "0x8EA46104": {
-      "name": "_0x8EA46104",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xD2A140BC": {
-      "name": "_0xD2A140BC",
-      "comment": "",
-      "params": [],
-      "return_type": "Any"
     }
   },
   "WEAPON": {
@@ -53671,10 +52917,217 @@
       "return_type": "Any"
     }
   },
-  "PC": {
-    "0x8CF09BD7": {
-      "name": "_0x8CF09BD7",
-      "comment": "PC only",
+  "WORLD": {
+    "0x9A93E7CA": {
+      "name": "CLEAR_AREA_OF_TREE_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x59A7835E": {
+      "name": "RESET_TREE_TYPE_CLEARING",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x25690082": {
+      "name": "RESET_THIS_TREE_TYPE_CLEARING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE92C3435": {
+      "name": "SET_DUST_LEVEL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xDB86F53B": {
+      "name": "SET_DUST_LEVEL_MODIFIER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8BA565F7": {
+      "name": "SET_DUST_LEVEL_MID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xB8E09389": {
+      "name": "SET_DUST_LEVEL_FAR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x9AA8A1B1": {
+      "name": "CLEAR_AREA_OF_GRASS",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x002B0698": {
+      "name": "CLEAR_AREA_OF_BREAKABLE_TREES",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x57478561": {
+      "name": "RESET_THIS_BREAKABLE_TREE_CLEARING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x39B0CFE5": {
+      "name": "RESET_ALL_BREAKABLE_TREE_CLEARINGS",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xDCAE6935": {
+      "name": "RELOAD_SMICTIONARY_LIST",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x28246500": {
+      "name": "SET_ZOMBIE_DLC_IS_ACTIVE",
+      "comment": "PS4/Switch/PC only",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x8CF15FCB": {
+      "name": "ZOMBIE_DLC_IS_ACTIVE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x4A8066FB": {
+      "name": "ZOMBIE_DLC_LOAD_ASSETS",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x1DDB57A6": {
+      "name": "ZOMBIE_DLC_LOAD_ASSETS_MP",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x88863344": {
+      "name": "ZOMBIE_DLC_UNLOAD_ASSETS",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xE7371670": {
+      "name": "ZOMBIE_DLC_IS_LOAD_COMPLETE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x03E2B631": {
+      "name": "ZOMBIE_DLC_IS_UNLOAD_COMPLETE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xCA840DBB": {
+      "name": "_SET_ZOMBIE_DLC_PHOSPHORUS_AMMO_ACTIVE",
+      "comment": "",
       "params": [
         {
           "type": "Any",
@@ -53683,9 +53136,15 @@
       ],
       "return_type": "Any"
     },
-    "0xBAE0A3F8": {
-      "name": "_0xBAE0A3F8",
-      "comment": "PC only",
+    "0x4F3F3CA5": {
+      "name": "_IS_ZOMBIE_DLC_PHOSPHORUS_AMMO_ACTIVE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xC587FA2B": {
+      "name": "CREATE_FIRE_ON_OBJECT",
+      "comment": "",
       "params": [
         {
           "type": "Any",
@@ -53694,9 +53153,654 @@
       ],
       "return_type": "Any"
     },
-    "0x9F832205": {
-      "name": "_0x9F832205",
-      "comment": "PC only",
+    "0xD4799325": {
+      "name": "CREATE_FIRE_IN_VOLUME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        },
+        {
+          "type": "Any",
+          "name": "p9"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x9544570A": {
+      "name": "STOP_ALL_FIRES",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x8011737F": {
+      "name": "_0x8011737F",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0x5402321A": {
+      "name": "CREATE_FIRE_PROPERTY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any*",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x2AC74780": {
+      "name": "GET_FIRE_PROPERTY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any*"
+    },
+    "0x466C02BA": {
+      "name": "STOP_ALL_FIRE_IN_SPHERE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xEC3A9EBB": {
+      "name": "STOP_ALL_FIRE_IN_VOLUME",
+      "comment": "",
+      "params": [],
+      "return_type": "void"
+    },
+    "0xADB3E8D9": {
+      "name": "REPLACE_WORLD_SECTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x08D06543": {
+      "name": "REPLACE_WORLD_SECTOR_LOAD_BOUNDING_BOX",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xAD5613FD": {
+      "name": "ENABLE_WORLD_SECTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xB511D087": {
+      "name": "DISABLE_WORLD_SECTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7ECE15BE": {
+      "name": "ENABLE_CHILD_SECTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x9E1AE585": {
+      "name": "DISABLE_CHILD_SECTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4E6A78B5": {
+      "name": "HIDE_CHILD_SECTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x63A83655": {
+      "name": "SHOW_CHILD_SECTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE437932A": {
+      "name": "SET_USE_ACTOR_STAGGER",
+      "comment": "PS4/Switch/PC only",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xBBAE9CBD": {
+      "name": "FIRE_CREATE_HANDLE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xA488E930": {
+      "name": "FIRE_IS_HANDLE_VALID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xB14B936A": {
+      "name": "FIRE_RELEASE_HANDLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xD2BB733E": {
+      "name": "_RELEASE_INFINITE_FIRE_DESCRIPTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        },
+        {
+          "type": "Any",
+          "name": "p9"
+        },
+        {
+          "type": "Any",
+          "name": "p10"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x91396EB7": {
+      "name": "_0x91396EB7",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x9679CF84": {
+      "name": "FIRE_CREATE_ON_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xB65ADFAC": {
+      "name": "FIRE_CREATE_IN_VOLUME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x30C4CA99": {
+      "name": "FIRE_IS_ACTOR_ON_FIRE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x15001332": {
+      "name": "FIRE_STOP_ALL_FIRES",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xF635B9EA": {
+      "name": "FIRE_STOP_ON_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x11A65FFB": {
+      "name": "FIRE_STOP_FLAMES_IN_VOLUME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x15683736": {
+      "name": "FIRE_GET_OWNER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE5C7E4C9": {
+      "name": "FIRE_SET_OWNER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x3D5D3B26": {
+      "name": "FIRE_SET_DAMAGE_ALLOWED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x03240324": {
+      "name": "FIRE_SET_CONTROL_VOLUME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE5E04E83": {
+      "name": "FIRE_SET_MAX_FLAMES",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x9C471E7D": {
+      "name": "FIRE_SET_TARGET_FILL_PERCENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x1A82B949": {
+      "name": "FIRE_SET_GROW_RATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7906A950": {
+      "name": "FIRE_SET_DECAY_RATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x6471D75C": {
+      "name": "FIRE_SET_EXPIRE_ALLOWED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x53895856": {
+      "name": "FIRE_SET_GROW_ALLOWED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xDEE6523D": {
+      "name": "COUNT_FLAMES_IN_SPHERE",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x3DD3E1EB": {
+      "name": "COUNT_FLAMES_IN_VOLUME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x28DAED2A": {
+      "name": "FIRE_ARE_ANY_FLAMES_IN_VOLUME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x3F67DEDB": {
+      "name": "FIRE_SET_GUNS_BLAZING_ACTIVE",
+      "comment": "",
+      "params": [
+        {
+          "type": "BOOL",
+          "name": "toggle"
+        }
+      ],
+      "return_type": "int"
+    }
+  },
+  "WORLD2": {
+    "0x9CD3AD70": {
+      "name": "FIND_INTERSECTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x6AD8EEAF": {
+      "name": "FIND_GROUND_INTERSECTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x77964B0C": {
+      "name": "FIND_GROUND_INTERSECTION_WITH_MATERIAL",
+      "comment": "",
       "params": [
         {
           "type": "Any",
@@ -53705,9 +53809,48 @@
       ],
       "return_type": "Any"
     },
-    "0xF413FDB2": {
-      "name": "_0xF413FDB2",
-      "comment": "PC only",
+    "0x4F193BE4": {
+      "name": "FIND_WATER_INTERSECTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x5219B7D0": {
+      "name": "GET_MATERIAL_AT_VECTOR",
+      "comment": "",
       "params": [
         {
           "type": "Any",
@@ -53716,9 +53859,9 @@
       ],
       "return_type": "Any"
     },
-    "0x63D3AAFC": {
-      "name": "_0x63D3AAFC",
-      "comment": "PC only",
+    "0x451A8EF2": {
+      "name": "GET_ACTOR_GROUND_MATERIAL",
+      "comment": "",
       "params": [
         {
           "type": "Any",
@@ -53727,152 +53870,9 @@
       ],
       "return_type": "Any"
     },
-    "0x3B93B981": {
-      "name": "_0x3B93B981",
-      "comment": "PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x854ACCFE": {
-      "name": "SET_HORSE_BREAK_INTRO",
-      "comment": "PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xEB0F9F0C": {
-      "name": "_0xEB0F9F0C",
-      "comment": "PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xFD198D8B": {
-      "name": "SET_SAVING_GAME",
-      "comment": "PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xA62D75BA": {
-      "name": "SET_SAVING_GAME_ZOMBIE",
-      "comment": "PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x7C730896": {
-      "name": "_0x7C730896",
-      "comment": "PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x02859CE6": {
-      "name": "_0x02859CE6",
-      "comment": "PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x5B47E49A": {
-      "name": "_0x5B47E49A",
-      "comment": "PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x97609434": {
-      "name": "_0x97609434",
-      "comment": "PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x920DB21": {
-      "name": "_0x0920DB21",
-      "comment": "PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x9CED1C7E": {
-      "name": "_0x9CED1C7E",
-      "comment": "PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xD9DDA7E2": {
-      "name": "_0xD9DDA7E2",
-      "comment": "PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x14664FF4": {
-      "name": "SET_USING_BINOCULARS",
-      "comment": "PC only",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xB0E60B63": {
-      "name": "_0xB0E60B63",
-      "comment": "PC only",
+    "0x1E81DB60": {
+      "name": "IS_POSITION_INDOORS",
+      "comment": "",
       "params": [
         {
           "type": "Any",

--- a/natives.json
+++ b/natives.json
@@ -2225,2284 +2225,6 @@
       "return_type": "int"
     }
   },
-  "ACTOR2": {
-    "0xBA6C3E92": {
-      "name": "IS_ACTOR_VALID",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x8B217CAC": {
-      "name": "GET_ACTORENUM_FROM_STRING",
-      "comment": "",
-      "params": [
-        {
-          "type": "const char*",
-          "name": "actorName"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x63D6551C": {
-      "name": "IS_ACTOR_ON_FOOT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xB7CE8FCC": {
-      "name": "GET_ACTOR_OFFSET_WORLD_COORDS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xB89CC342": {
-      "name": "_0xB89CC342",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x50A3BF5D": {
-      "name": "ACTORS_IN_RANGE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xAD6AF65C": {
-      "name": "GET_ACTOR_VELOCITY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any*",
-          "name": "p1"
-        },
-        {
-          "type": "Any*",
-          "name": "p2"
-        },
-        {
-          "type": "Any*",
-          "name": "p3"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0xE173CE48": {
-      "name": "GET_ACTOR_HEIGHT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0xAB8A1C15": {
-      "name": "SET_GLOBAL_ACTOR_WEAPON_BIAS",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int*"
-    },
-    "0xDAD46FAB": {
-      "name": "RESET_GLOBAL_ACTOR_WEAPON_BIAS",
-      "comment": "",
-      "params": [],
-      "return_type": "const char*"
-    },
-    "0xA2DEC153": {
-      "name": "_ACTOR_IN_WORLD",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5F655C68": {
-      "name": "IS_AREA_OBSTRUCTED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x0733E811": {
-      "name": "IS_AREA_OBSTRUCTED2",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        },
-        {
-          "type": "float",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x6AC01FCB": {
-      "name": "GET_ACTORENUM_SPECIES",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xEE0AB3DD": {
-      "name": "_GET_ACTOR_BASE_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x6AFF3122": {
-      "name": "GET_ACTORENUM_AVATAR_GROUP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7D397CAA": {
-      "name": "_GET_MP_ANIM_SET_NAME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8DAC4359": {
-      "name": "DECOR_HANDLES_RELATIVE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xDE0B9673": {
-      "name": "SET_ACTOR_STAMINA",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xAC232F6E": {
-      "name": "GET_ACTOR_GAIT_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xDB993A4F": {
-      "name": "GET_ACTOR_POSTURE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x708D9BD3": {
-      "name": "SET_ACTOR_POSTURE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xDCC91F8C": {
-      "name": "RESET_ACTOR_GAITS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "const char*",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xABFD3560": {
-      "name": "GET_ACTOR_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x2091F142": {
-      "name": "IS_ACTOR_MALE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x9C42B7A2": {
-      "name": "SET_ACTOR_SEX",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4C94EB9E": {
-      "name": "SET_ACTOR_IS_COMPANION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x8392855D": {
-      "name": "SET_ACTOR_IS_THE_BEASTMASTER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE9D86A7A": {
-      "name": "SET_ACTOR_TIME_OF_LAST_CRIME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x2CB5D7AF": {
-      "name": "DESTROY_IMPAIRED_ACTORS",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x0A842786": {
-      "name": "IS_PLAYER_WEAPON_ZOOMED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x8E0769F3": {
-      "name": "IS_ACTOR_ANIMAL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xF6BF4242": {
-      "name": "IS_ACTOR_CROUCHING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x25670955": {
-      "name": "IS_ACTOR_FLYING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x882C84DC": {
-      "name": "IS_ACTOR_HUMAN",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xDFF96719": {
-      "name": "IS_ACTOR_JUMPING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x4B441DC4": {
-      "name": "IS_ACTOR_SHOOTING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x6396ABB7": {
-      "name": "IS_ACTOR_BLINDFIRING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x39C518DB": {
-      "name": "IS_ACTOR_RELOADING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x886BD8AD": {
-      "name": "IS_ACTOR_THROWING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x3612AC73": {
-      "name": "IS_ACTOR_WHISTLING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xE975BE40": {
-      "name": "IS_ACTOR_ON_LADDER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xE27EBCBD": {
-      "name": "IS_ACTOR_OUTDOORS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x017D270E": {
-      "name": "SUSPEND_MOVER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE29F0A39": {
-      "name": "ENABLE_MOVER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x13E6B5EE": {
-      "name": "SET_MOVER_FROZEN",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x9C12BD5A": {
-      "name": "IS_MOVER_FROZEN",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x63925367": {
-      "name": "SET_ACTOR_USE_COARSE_BOUNDS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x61664EC0": {
-      "name": "_SUPPRESS_MOVE_COLLISIONS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x709EC06C": {
-      "name": "IS_ACTOR_ON_GROUND",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x8ED9DAFC": {
-      "name": "IS_ACTOR_ON_PATH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x4A2DE1D0": {
-      "name": "_IS_MOVER_ON_VEHICLE_PATH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7D65D9C7": {
-      "name": "IS_ACTOR_IN_WATER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xA6AA7B9E": {
-      "name": "_IS_ACTOR_IN_WATER_OF_DEPTH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "float",
-          "name": "p5"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x7B4F9EAC": {
-      "name": "GET_ACTOR_STUCK_STATE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xE39E89BD": {
-      "name": "IS_ACTOR_IN_FIRE_VOLUME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8842C62D": {
-      "name": "IS_ACTOR_RIDEABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x19F3CB6B": {
-      "name": "SET_ACTOR_RIDEABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "BOOL",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x04CF7C3E": {
-      "name": "GET_VEHICLE_BUMP_COUNT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x0E9BA223": {
-      "name": "RESET_VEHICLE_BUMP_COUNT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x5FEA3E61": {
-      "name": "SET_CUSTOM_ANIM_SPEED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x35D8B4AA": {
-      "name": "ACTOR_RESET_ANIMS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x817B6952": {
-      "name": "_0x817B6952",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x4A1D2E25": {
-      "name": "_0x4A1D2E25",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xC17BAD12": {
-      "name": "_0xC17BAD12",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x0B5E1904": {
-      "name": "SET_ACTOR_CAN_PLAY_BORED_IDLES",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x50ED77F1": {
-      "name": "SET_ACTOR_CAN_PLAY_GESTURES",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xDA2F6203": {
-      "name": "ACTOR_ENABLE_VARIABLE_MESH",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x5DE31288": {
-      "name": "ACTOR_IS_VARIABLE_MESH_ENABLED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x6D3E430D": {
-      "name": "ACTOR_SET_GRABBED_BY_CUTSCENE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x776999DB": {
-      "name": "ACTOR_IS_GRABBED_BY_CUTSCENE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x488C95C4": {
-      "name": "ACTOR_IS_HIDDEN_BY_CUTSCENE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x0CC3D8F6": {
-      "name": "_IS_ACTOR_FULLY_FADED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0x55AACDFD": {
-      "name": "SET_ACTOR_HEARING_MAX_RANGE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x21CE712F": {
-      "name": "GET_ACTOR_VISION_FIELD_OF_VIEW",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0xF8F3FE84": {
-      "name": "SET_ACTOR_VISION_FIELD_OF_VIEW",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x4A4B4B26": {
-      "name": "GET_ACTOR_VISION_MAX_RANGE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x4E3E9B70": {
-      "name": "SET_ACTOR_VISION_MAX_RANGE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5C8DD257": {
-      "name": "SET_UNIVERSAL_VISION_RANGE_MULTIPLIER",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8D5175A8": {
-      "name": "SET_ACTOR_VISION_XRAY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xBFABD82E": {
-      "name": "GET_ACTOR_VISION_XRAY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xAAC96EFF": {
-      "name": "GET_ACTOR_CURRENT_WEAPON_AI_PARAMETERS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x9CD3385E": {
-      "name": "GET_ACTOR_ALLOW_BUMP_REACTIONS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xC52B5F18": {
-      "name": "SET_ACTOR_ALLOW_BUMP_REACTIONS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "BOOL",
-          "name": "toggle"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xEB7B0FAA": {
-      "name": "_0xEB7B0FAA",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x2C6A5FAC": {
-      "name": "SET_RCM_ACTOR_CALL_OVER_ENABLE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        },
-        {
-          "type": "Any",
-          "name": "p9"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xE4AA7B35": {
-      "name": "SET_RCM_WAS_JOHN_NOW_JACK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xD15B53F8": {
-      "name": "SET_RCM_ACTOR_CALL_OVER_SUPPRESS",
-      "comment": "",
-      "params": [
-        {
-          "type": "float",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int*"
-    },
-    "0xC28A5950": {
-      "name": "_SET_ALLOW_PLAYER_GREET_RESPONSES",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x003D7C2F": {
-      "name": "SET_ACTOR_ALLOW_WEAPON_REACTIONS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "actor"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xBAF9D599": {
-      "name": "SET_ACTOR_ALLOW_WEAPON_REACTION_FLEE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x78B7976E": {
-      "name": "GET_ACTOR_WEAPON_REACTION_ACTOR_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Actor",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x18BA1216": {
-      "name": "SET_ACTOR_WEAPON_REACTION_ACTOR_TYPE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0634B4D1": {
-      "name": "SET_PLAYER_CAUSE_WEAPON_REACTIONS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        },
-        {
-          "type": "Any",
-          "name": "p9"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xD9934D6E": {
-      "name": "SET_ACTOR_WEAPON_REACTION_NO_FLEE_HACK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0A23F215": {
-      "name": "SET_ACTOR_OBSERVED_TARGETED_REACTIONS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xFFDA2D88": {
-      "name": "SET_PLAYER_CAUSE_WEAPON_REACTION_COMBAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x7B7D1742": {
-      "name": "SET_ACTOR_REACT_TO_LASSO",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "const char*",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x76A72D9A": {
-      "name": "SET_ACTOR_ALLOW_DISARM",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "const char*",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x2B403538": {
-      "name": "SET_ANIMAL_CAN_ATTACK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x5D9DB7A5": {
-      "name": "GET_CURRENT_GRINGO",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x527CB774": {
-      "name": "SET_ACTOR_GRINGO_RESTRICTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x660DBDDD": {
-      "name": "CLEAR_ACTOR_GRINGO_RESTRICTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xF04335A6": {
-      "name": "MAKE_ACTOR_READY_FOR_ACTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xFB2B0CCF": {
-      "name": "IS_ACTOR_READY_FOR_ACTION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "BOOL"
-    },
-    "0xA41B161C": {
-      "name": "REPORT_GRINGO_USE_PHASE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x9028B082": {
-      "name": "CLEAR_ALL_CORPSES",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0x90F9555B": {
-      "name": "CAN_PLAYER_DIE",
-      "comment": "",
-      "params": [],
-      "return_type": "int"
-    },
-    "0xA9691E66": {
-      "name": "CLEAR_ACTOR_MAX_SPEED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x9CB01B27": {
-      "name": "SET_ACTOR_MAX_SPEED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x950B8870": {
-      "name": "SET_ACTOR_MAX_SPEED_ABSOLUTE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x036D75D5": {
-      "name": "CLEAR_ACTOR_MIN_SPEED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xA854EE99": {
-      "name": "SET_ACTOR_MIN_SPEED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x04D4A734": {
-      "name": "SET_ACTOR_MIN_SPEED_ABSOLUTE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x627E52EA": {
-      "name": "GET_ACTOR_MAX_SPEED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x56DE7F21": {
-      "name": "GET_ACTOR_MAX_SPEED_ABSOLUTE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8D0DCEB6": {
-      "name": "GET_ACTOR_MIN_SPEED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x09D78931": {
-      "name": "SET_ACTOR_SPEED",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x68D4A021": {
-      "name": "CLEAR_LAST_ATTACK",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xEB40C2FC": {
-      "name": "GET_LAST_ATTACK_TARGET",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x69FA5315": {
-      "name": "GET_LAST_ATTACK_TIME",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0x8C221B4D": {
-      "name": "_0x8C221B4D",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0x0129B715": {
-      "name": "GET_ACTOR_COMBAT_CLASS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8062BD74": {
-      "name": "_0x8062BD74",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "float",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x44B7FF7E": {
-      "name": "BEGIN_DUEL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        },
-        {
-          "type": "Any",
-          "name": "p7"
-        },
-        {
-          "type": "Any",
-          "name": "p8"
-        },
-        {
-          "type": "Any",
-          "name": "p9"
-        },
-        {
-          "type": "Any",
-          "name": "p10"
-        },
-        {
-          "type": "Any",
-          "name": "p11"
-        },
-        {
-          "type": "Any",
-          "name": "p12"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x4E86F0B5": {
-      "name": "CANCEL_DUEL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        }
-      ],
-      "return_type": "Any"
-    },
-    "0x82A6B8FC": {
-      "name": "ADD_DUEL_HOSTAGE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x33CE5435": {
-      "name": "GET_CURRENT_DUEL_SCORE",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x3E5C3C2D": {
-      "name": "SET_DUEL_DIFFICULTY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x8007587C": {
-      "name": "GET_ACTOR_EXEMPT_FROM_AMBIENT_RESTRICTIONS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x4D0A87BF": {
-      "name": "SET_ACTOR_EXEMPT_FROM_AMBIENT_RESTRICTIONS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x6695E185": {
-      "name": "ADD_CAPABILITY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x29AEB2DB": {
-      "name": "REMOVE_CAPABILITY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xD3D8E8ED": {
-      "name": "HAS_CAPABILITY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x2B8C3258": {
-      "name": "GET_LAST_ON_SCREEN_TIME_FOR_ACTOR",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "float"
-    },
-    "0xA4B5275C": {
-      "name": "NET_SET_NODE_REPLICATION",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x382E7CCC": {
-      "name": "SET_ACTOR_ACTION_SIGNAL",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x415F9BC3": {
-      "name": "TOGGLE_ACTOR_ACTION_SIGNAL_ON",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4F605632": {
-      "name": "TOGGLE_ACTOR_ACTION_SIGNAL_OFF",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x02365961": {
-      "name": "GET_ACTOR_MELEE_TARGETED_BY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any*",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xD079EB62": {
-      "name": "SET_ACTOR_CAN_DEADEYE_TAG_ANYTHING",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x47930AA4": {
-      "name": "SET_ACTOR_AUTO_TRANSITION_TO_DRIVER_SEAT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xEDC806BA": {
-      "name": "SET_ACTOR_FLY_FX",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x7A746D3A": {
-      "name": "SET_ACTOR_MOVE_CONFLICT_HIGH_PRIORITY",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x32CB0E86": {
-      "name": "SET_ACTOR_MOVE_CONFLICT_ALLOWED_TO_RUN_OVER_SMALL_ANIMALS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x4CB24141": {
-      "name": "SET_ACTOR_IS_AMBIENT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x0880DBF5": {
-      "name": "SET_ACTOR_IS_SHOPKEEPER",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0x199600FA": {
-      "name": "SET_ACTOR_SHOULD_TAUNT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xB9744BE7": {
-      "name": "SET_ACTOR_CAN_BUMP",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "void"
-    },
-    "0xBADB24FB": {
-      "name": "SET_ACTOR_MAX_FRESHNESS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0xF1D2A13E": {
-      "name": "GET_ACTOR_MAX_FRESHNESS",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x5E54E254": {
-      "name": "MAKE_BIRD_FLY_FROM_POINT",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "Any",
-          "name": "p1"
-        },
-        {
-          "type": "Any",
-          "name": "p2"
-        },
-        {
-          "type": "Any",
-          "name": "p3"
-        },
-        {
-          "type": "Any",
-          "name": "p4"
-        },
-        {
-          "type": "Any",
-          "name": "p5"
-        },
-        {
-          "type": "Any",
-          "name": "p6"
-        }
-      ],
-      "return_type": "void"
-    }
-  },
   "ACTORSET": {
     "0x009DFC82": {
       "name": "CREATE_ACTORSET_IN_LAYOUT",
@@ -4629,6 +2351,30 @@
     },
     "0xA24F4799": {
       "name": "GET_ACTORSET_SIZE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    }
+  },
+  "ACTOR_DRAW": {
+    "0xE6644CE5": {
+      "name": "SET_DRAW_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x085A9CA6": {
+      "name": "GET_DRAW_ACTOR",
       "comment": "",
       "params": [
         {
@@ -12108,7 +9854,7 @@
       "return_type": "int"
     },
     "0x2B1B76E8": {
-      "name": "_0x2B1B76E8",
+      "name": "AUDIO_TURN_ON_PAIN_VOCALS",
       "comment": "",
       "params": [
         {
@@ -20057,8 +17803,607 @@
     }
   },
   "ENTITY": {
-    "0xE6644CE5": {
-      "name": "SET_DRAW_ACTOR",
+    "0xBA6C3E92": {
+      "name": "IS_ACTOR_VALID",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x8B217CAC": {
+      "name": "GET_ACTORENUM_FROM_STRING",
+      "comment": "",
+      "params": [
+        {
+          "type": "const char*",
+          "name": "actorName"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x63D6551C": {
+      "name": "IS_ACTOR_ON_FOOT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xB7CE8FCC": {
+      "name": "GET_ACTOR_OFFSET_WORLD_COORDS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xB89CC342": {
+      "name": "_0xB89CC342",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x50A3BF5D": {
+      "name": "ACTORS_IN_RANGE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xAD6AF65C": {
+      "name": "GET_ACTOR_VELOCITY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any*",
+          "name": "p1"
+        },
+        {
+          "type": "Any*",
+          "name": "p2"
+        },
+        {
+          "type": "Any*",
+          "name": "p3"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0xE173CE48": {
+      "name": "GET_ACTOR_HEIGHT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0xAB8A1C15": {
+      "name": "SET_GLOBAL_ACTOR_WEAPON_BIAS",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int*"
+    },
+    "0xDAD46FAB": {
+      "name": "RESET_GLOBAL_ACTOR_WEAPON_BIAS",
+      "comment": "",
+      "params": [],
+      "return_type": "const char*"
+    },
+    "0xA2DEC153": {
+      "name": "_ACTOR_IN_WORLD",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5F655C68": {
+      "name": "IS_AREA_OBSTRUCTED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x0733E811": {
+      "name": "IS_AREA_OBSTRUCTED2",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        },
+        {
+          "type": "float",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x6AC01FCB": {
+      "name": "GET_ACTORENUM_SPECIES",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xEE0AB3DD": {
+      "name": "_GET_ACTOR_BASE_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x6AFF3122": {
+      "name": "GET_ACTORENUM_AVATAR_GROUP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7D397CAA": {
+      "name": "_GET_MP_ANIM_SET_NAME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8DAC4359": {
+      "name": "DECOR_HANDLES_RELATIVE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xDE0B9673": {
+      "name": "SET_ACTOR_STAMINA",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xAC232F6E": {
+      "name": "GET_ACTOR_GAIT_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xDB993A4F": {
+      "name": "GET_ACTOR_POSTURE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x708D9BD3": {
+      "name": "SET_ACTOR_POSTURE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xDCC91F8C": {
+      "name": "RESET_ACTOR_GAITS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "const char*",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xABFD3560": {
+      "name": "GET_ACTOR_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x2091F142": {
+      "name": "IS_ACTOR_MALE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x9C42B7A2": {
+      "name": "SET_ACTOR_SEX",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4C94EB9E": {
+      "name": "SET_ACTOR_IS_COMPANION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x8392855D": {
+      "name": "SET_ACTOR_IS_THE_BEASTMASTER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE9D86A7A": {
+      "name": "SET_ACTOR_TIME_OF_LAST_CRIME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x2CB5D7AF": {
+      "name": "DESTROY_IMPAIRED_ACTORS",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x0A842786": {
+      "name": "IS_PLAYER_WEAPON_ZOOMED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x8E0769F3": {
+      "name": "IS_ACTOR_ANIMAL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xF6BF4242": {
+      "name": "IS_ACTOR_CROUCHING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x25670955": {
+      "name": "IS_ACTOR_FLYING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x882C84DC": {
+      "name": "IS_ACTOR_HUMAN",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xDFF96719": {
+      "name": "IS_ACTOR_JUMPING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x4B441DC4": {
+      "name": "IS_ACTOR_SHOOTING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x6396ABB7": {
+      "name": "IS_ACTOR_BLINDFIRING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x39C518DB": {
+      "name": "IS_ACTOR_RELOADING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x886BD8AD": {
+      "name": "IS_ACTOR_THROWING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x3612AC73": {
+      "name": "IS_ACTOR_WHISTLING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xE975BE40": {
+      "name": "IS_ACTOR_ON_LADDER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xE27EBCBD": {
+      "name": "IS_ACTOR_OUTDOORS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x017D270E": {
+      "name": "SUSPEND_MOVER",
       "comment": "",
       "params": [
         {
@@ -20068,8 +18413,892 @@
       ],
       "return_type": "void"
     },
-    "0x085A9CA6": {
-      "name": "GET_DRAW_ACTOR",
+    "0xE29F0A39": {
+      "name": "ENABLE_MOVER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x13E6B5EE": {
+      "name": "SET_MOVER_FROZEN",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x9C12BD5A": {
+      "name": "IS_MOVER_FROZEN",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x63925367": {
+      "name": "SET_ACTOR_USE_COARSE_BOUNDS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x61664EC0": {
+      "name": "_SUPPRESS_MOVE_COLLISIONS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x709EC06C": {
+      "name": "IS_ACTOR_ON_GROUND",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x8ED9DAFC": {
+      "name": "IS_ACTOR_ON_PATH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x4A2DE1D0": {
+      "name": "_IS_MOVER_ON_VEHICLE_PATH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7D65D9C7": {
+      "name": "IS_ACTOR_IN_WATER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xA6AA7B9E": {
+      "name": "_IS_ACTOR_IN_WATER_OF_DEPTH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "float",
+          "name": "p5"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x7B4F9EAC": {
+      "name": "GET_ACTOR_STUCK_STATE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xE39E89BD": {
+      "name": "IS_ACTOR_IN_FIRE_VOLUME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8842C62D": {
+      "name": "IS_ACTOR_RIDEABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x19F3CB6B": {
+      "name": "SET_ACTOR_RIDEABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "BOOL",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x04CF7C3E": {
+      "name": "GET_VEHICLE_BUMP_COUNT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x0E9BA223": {
+      "name": "RESET_VEHICLE_BUMP_COUNT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x5FEA3E61": {
+      "name": "SET_CUSTOM_ANIM_SPEED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x35D8B4AA": {
+      "name": "ACTOR_RESET_ANIMS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x817B6952": {
+      "name": "_0x817B6952",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x4A1D2E25": {
+      "name": "_0x4A1D2E25",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xC17BAD12": {
+      "name": "_0xC17BAD12",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x0B5E1904": {
+      "name": "SET_ACTOR_CAN_PLAY_BORED_IDLES",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x50ED77F1": {
+      "name": "SET_ACTOR_CAN_PLAY_GESTURES",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xDA2F6203": {
+      "name": "ACTOR_ENABLE_VARIABLE_MESH",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x5DE31288": {
+      "name": "ACTOR_IS_VARIABLE_MESH_ENABLED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x6D3E430D": {
+      "name": "ACTOR_SET_GRABBED_BY_CUTSCENE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x776999DB": {
+      "name": "ACTOR_IS_GRABBED_BY_CUTSCENE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x488C95C4": {
+      "name": "ACTOR_IS_HIDDEN_BY_CUTSCENE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x0CC3D8F6": {
+      "name": "_IS_ACTOR_FULLY_FADED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0x55AACDFD": {
+      "name": "SET_ACTOR_HEARING_MAX_RANGE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x21CE712F": {
+      "name": "GET_ACTOR_VISION_FIELD_OF_VIEW",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0xF8F3FE84": {
+      "name": "SET_ACTOR_VISION_FIELD_OF_VIEW",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x4A4B4B26": {
+      "name": "GET_ACTOR_VISION_MAX_RANGE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x4E3E9B70": {
+      "name": "SET_ACTOR_VISION_MAX_RANGE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5C8DD257": {
+      "name": "SET_UNIVERSAL_VISION_RANGE_MULTIPLIER",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8D5175A8": {
+      "name": "SET_ACTOR_VISION_XRAY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xBFABD82E": {
+      "name": "GET_ACTOR_VISION_XRAY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xAAC96EFF": {
+      "name": "GET_ACTOR_CURRENT_WEAPON_AI_PARAMETERS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x9CD3385E": {
+      "name": "GET_ACTOR_ALLOW_BUMP_REACTIONS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xC52B5F18": {
+      "name": "SET_ACTOR_ALLOW_BUMP_REACTIONS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "BOOL",
+          "name": "toggle"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xEB7B0FAA": {
+      "name": "_0xEB7B0FAA",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x2C6A5FAC": {
+      "name": "SET_RCM_ACTOR_CALL_OVER_ENABLE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        },
+        {
+          "type": "Any",
+          "name": "p9"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xE4AA7B35": {
+      "name": "SET_RCM_WAS_JOHN_NOW_JACK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xD15B53F8": {
+      "name": "SET_RCM_ACTOR_CALL_OVER_SUPPRESS",
+      "comment": "",
+      "params": [
+        {
+          "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int*"
+    },
+    "0xC28A5950": {
+      "name": "_SET_ALLOW_PLAYER_GREET_RESPONSES",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x003D7C2F": {
+      "name": "SET_ACTOR_ALLOW_WEAPON_REACTIONS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "actor"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xBAF9D599": {
+      "name": "SET_ACTOR_ALLOW_WEAPON_REACTION_FLEE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x78B7976E": {
+      "name": "GET_ACTOR_WEAPON_REACTION_ACTOR_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Actor",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x18BA1216": {
+      "name": "SET_ACTOR_WEAPON_REACTION_ACTOR_TYPE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0634B4D1": {
+      "name": "SET_PLAYER_CAUSE_WEAPON_REACTIONS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        },
+        {
+          "type": "Any",
+          "name": "p9"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xD9934D6E": {
+      "name": "SET_ACTOR_WEAPON_REACTION_NO_FLEE_HACK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0A23F215": {
+      "name": "SET_ACTOR_OBSERVED_TARGETED_REACTIONS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xFFDA2D88": {
+      "name": "SET_PLAYER_CAUSE_WEAPON_REACTION_COMBAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x7B7D1742": {
+      "name": "SET_ACTOR_REACT_TO_LASSO",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "const char*",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x76A72D9A": {
+      "name": "SET_ACTOR_ALLOW_DISARM",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "const char*",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x2B403538": {
+      "name": "SET_ANIMAL_CAN_ATTACK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x5D9DB7A5": {
+      "name": "GET_CURRENT_GRINGO",
       "comment": "",
       "params": [
         {
@@ -20078,6 +19307,777 @@
         }
       ],
       "return_type": "Any"
+    },
+    "0x527CB774": {
+      "name": "SET_ACTOR_GRINGO_RESTRICTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x660DBDDD": {
+      "name": "CLEAR_ACTOR_GRINGO_RESTRICTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xF04335A6": {
+      "name": "MAKE_ACTOR_READY_FOR_ACTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xFB2B0CCF": {
+      "name": "IS_ACTOR_READY_FOR_ACTION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "BOOL"
+    },
+    "0xA41B161C": {
+      "name": "REPORT_GRINGO_USE_PHASE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x9028B082": {
+      "name": "CLEAR_ALL_CORPSES",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0x90F9555B": {
+      "name": "CAN_PLAYER_DIE",
+      "comment": "",
+      "params": [],
+      "return_type": "int"
+    },
+    "0xA9691E66": {
+      "name": "CLEAR_ACTOR_MAX_SPEED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x9CB01B27": {
+      "name": "SET_ACTOR_MAX_SPEED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x950B8870": {
+      "name": "SET_ACTOR_MAX_SPEED_ABSOLUTE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x036D75D5": {
+      "name": "CLEAR_ACTOR_MIN_SPEED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xA854EE99": {
+      "name": "SET_ACTOR_MIN_SPEED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x04D4A734": {
+      "name": "SET_ACTOR_MIN_SPEED_ABSOLUTE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x627E52EA": {
+      "name": "GET_ACTOR_MAX_SPEED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x56DE7F21": {
+      "name": "GET_ACTOR_MAX_SPEED_ABSOLUTE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8D0DCEB6": {
+      "name": "GET_ACTOR_MIN_SPEED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x09D78931": {
+      "name": "SET_ACTOR_SPEED",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x68D4A021": {
+      "name": "CLEAR_LAST_ATTACK",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xEB40C2FC": {
+      "name": "GET_LAST_ATTACK_TARGET",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x69FA5315": {
+      "name": "GET_LAST_ATTACK_TIME",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0x8C221B4D": {
+      "name": "_0x8C221B4D",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0x0129B715": {
+      "name": "GET_ACTOR_COMBAT_CLASS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8062BD74": {
+      "name": "_0x8062BD74",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "float",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x44B7FF7E": {
+      "name": "BEGIN_DUEL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        },
+        {
+          "type": "Any",
+          "name": "p7"
+        },
+        {
+          "type": "Any",
+          "name": "p8"
+        },
+        {
+          "type": "Any",
+          "name": "p9"
+        },
+        {
+          "type": "Any",
+          "name": "p10"
+        },
+        {
+          "type": "Any",
+          "name": "p11"
+        },
+        {
+          "type": "Any",
+          "name": "p12"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x4E86F0B5": {
+      "name": "CANCEL_DUEL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        }
+      ],
+      "return_type": "Any"
+    },
+    "0x82A6B8FC": {
+      "name": "ADD_DUEL_HOSTAGE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x33CE5435": {
+      "name": "GET_CURRENT_DUEL_SCORE",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x3E5C3C2D": {
+      "name": "SET_DUEL_DIFFICULTY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x8007587C": {
+      "name": "GET_ACTOR_EXEMPT_FROM_AMBIENT_RESTRICTIONS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x4D0A87BF": {
+      "name": "SET_ACTOR_EXEMPT_FROM_AMBIENT_RESTRICTIONS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x6695E185": {
+      "name": "ADD_CAPABILITY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x29AEB2DB": {
+      "name": "REMOVE_CAPABILITY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xD3D8E8ED": {
+      "name": "HAS_CAPABILITY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x2B8C3258": {
+      "name": "GET_LAST_ON_SCREEN_TIME_FOR_ACTOR",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "float"
+    },
+    "0xA4B5275C": {
+      "name": "NET_SET_NODE_REPLICATION",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x382E7CCC": {
+      "name": "SET_ACTOR_ACTION_SIGNAL",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x415F9BC3": {
+      "name": "TOGGLE_ACTOR_ACTION_SIGNAL_ON",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4F605632": {
+      "name": "TOGGLE_ACTOR_ACTION_SIGNAL_OFF",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x02365961": {
+      "name": "GET_ACTOR_MELEE_TARGETED_BY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any*",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xD079EB62": {
+      "name": "SET_ACTOR_CAN_DEADEYE_TAG_ANYTHING",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x47930AA4": {
+      "name": "SET_ACTOR_AUTO_TRANSITION_TO_DRIVER_SEAT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xEDC806BA": {
+      "name": "SET_ACTOR_FLY_FX",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x7A746D3A": {
+      "name": "SET_ACTOR_MOVE_CONFLICT_HIGH_PRIORITY",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x32CB0E86": {
+      "name": "SET_ACTOR_MOVE_CONFLICT_ALLOWED_TO_RUN_OVER_SMALL_ANIMALS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x4CB24141": {
+      "name": "SET_ACTOR_IS_AMBIENT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x0880DBF5": {
+      "name": "SET_ACTOR_IS_SHOPKEEPER",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0x199600FA": {
+      "name": "SET_ACTOR_SHOULD_TAUNT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xB9744BE7": {
+      "name": "SET_ACTOR_CAN_BUMP",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "void"
+    },
+    "0xBADB24FB": {
+      "name": "SET_ACTOR_MAX_FRESHNESS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0xF1D2A13E": {
+      "name": "GET_ACTOR_MAX_FRESHNESS",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x5E54E254": {
+      "name": "MAKE_BIRD_FLY_FROM_POINT",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "Any",
+          "name": "p1"
+        },
+        {
+          "type": "Any",
+          "name": "p2"
+        },
+        {
+          "type": "Any",
+          "name": "p3"
+        },
+        {
+          "type": "Any",
+          "name": "p4"
+        },
+        {
+          "type": "Any",
+          "name": "p5"
+        },
+        {
+          "type": "Any",
+          "name": "p6"
+        }
+      ],
+      "return_type": "void"
     }
   },
   "EVENT": {
@@ -39742,34 +39742,6 @@
       "return_type": "int"
     }
   },
-  "OBJECT2": {
-    "0x7080E24A": {
-      "name": "_0x7080E24A",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        },
-        {
-          "type": "float",
-          "name": "p1"
-        }
-      ],
-      "return_type": "int"
-    },
-    "0x1D7845B7": {
-      "name": "_0x1D7845B7",
-      "comment": "",
-      "params": [
-        {
-          "type": "Any",
-          "name": "p0"
-        }
-      ],
-      "return_type": "void"
-    }
-  },
   "PATH": {
     "0x44930268": {
       "name": "SET_PATH_LOOPING",
@@ -42242,6 +42214,34 @@
       "params": [
         {
           "type": "float",
+          "name": "p0"
+        }
+      ],
+      "return_type": "void"
+    }
+  },
+  "PROBE": {
+    "0x7080E24A": {
+      "name": "_0x7080E24A",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
+          "name": "p0"
+        },
+        {
+          "type": "float",
+          "name": "p1"
+        }
+      ],
+      "return_type": "int"
+    },
+    "0x1D7845B7": {
+      "name": "_0x1D7845B7",
+      "comment": "",
+      "params": [
+        {
+          "type": "Any",
           "name": "p0"
         }
       ],


### PR DESCRIPTION
Natives 3429 -> 3492
Known names 2865 -> 2952

Categories are based on the NSW symbol for the func that registers those commands, eg. AI_RIDE is from `aiScript::SetupScriptCommandsRide`

Got all the UNK categories named, there are still some dupes like ACTOR/ACTOR2 OBJECT/OBJECT2 though, game uses similar func names for both of those and couldn't think of anything better (wonder if it's something like RAGE-script-cmds vs RDR-script-cmds...)